### PR TITLE
Reworked how sessions are initiated

### DIFF
--- a/ExilenceNextApp/src/store/domains/account-league.ts
+++ b/ExilenceNextApp/src/store/domains/account-league.ts
@@ -1,7 +1,6 @@
-import { AxiosResponse, AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { action, observable, runInAction } from 'mobx';
 import { persist } from 'mobx-persist';
-import { fromStream } from 'mobx-utils';
 import { of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { ICharacter } from '../../interfaces/character.interface';
@@ -34,24 +33,22 @@ export class AccountLeague {
 
   @action
   getStashTabs() {
-    fromStream(
-      externalService
-        .getStashTabs(
-          stores.accountStore.getSelectedAccount.name,
-          this.leagueId
-        )
-        .pipe(
-          map((response: AxiosResponse<IStash>) => {
-            runInAction(() => {
-              if (response.data.tabs.length > 0) {
-                this.stashtabs = response.data.tabs;
-              }
-              this.getStashTabsSuccess();
-            });
-          }),
-          catchError((e: AxiosError) => of(this.getStashTabsFail(e)))
-        ),   
-    );
+    return externalService
+      .getStashTabs(stores.accountStore.getSelectedAccount.name, this.leagueId)
+      .pipe(
+        map((response: AxiosResponse<IStash>) => {
+          runInAction(() => {
+            if (response.data.tabs.length > 0) {
+              this.stashtabs = response.data.tabs;
+            }
+            this.getStashTabsSuccess();
+          });
+        }),
+        catchError((e: AxiosError) => {
+          of(this.getStashTabsFail(e));
+          throw e;
+        })
+      );
   }
 
   @action getStashTabsSuccess() {

--- a/ExilenceNextApp/src/store/domains/account.ts
+++ b/ExilenceNextApp/src/store/domains/account.ts
@@ -97,11 +97,4 @@ export class Account implements IAccount {
     this.profiles.push(created);
     this.setActiveProfile(created.uuid);
   }
-
-  @action
-  getAllStashTabs() {
-    this.accountLeagues.forEach(l => {
-      l.getStashTabs();
-    });
-  }
 }

--- a/ExilenceNextApp/src/store/priceStore.ts
+++ b/ExilenceNextApp/src/store/priceStore.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { action, observable } from 'mobx';
 import { fromStream } from 'mobx-utils';
 import { forkJoin, from, of } from 'rxjs';
@@ -11,7 +12,6 @@ import { PriceSource } from './domains/price-source';
 import { LeagueStore } from './leagueStore';
 import { NotificationStore } from './notificationStore';
 import { UiStateStore } from './uiStateStore';
-import { AxiosError } from 'axios';
 
 
 export class PriceStore {
@@ -129,7 +129,7 @@ export class PriceStore {
   }
 
   @action
-  getPricesforLeaguesFail(error: AxiosError | string) {
+  getPricesforLeaguesFail(e: AxiosError | string) {
     this.isUpdatingPrices = false;
     this.notificationStore.createNotification(
       'get_prices_for_leagues',


### PR DESCRIPTION
Previously we did not wait for stash tabs to be fetched when initiating a new session. Now we wait for each of them to be fetched before continuing, and throws error otherwhise.

Fixes #79 