### PR TITLE
Features/sentry integration

### DIFF
--- a/ExilenceNextApp/package-lock.json
+++ b/ExilenceNextApp/package-lock.json
@@ -1325,6 +1325,214 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@sentry/browser": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.9.1.tgz",
+      "integrity": "sha512-7AOabwp9yAH9h6Xe6TfDwlLxHbUSWs+SPWHI7bPlht2yDSAqkXYGSzRr5X0XQJX9oBQdx2cEPMqHyJrbNaP/og==",
+      "requires": {
+        "@sentry/core": "5.8.0",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.8.0.tgz",
+      "integrity": "sha512-aAh2KLidIXJVGrxmHSVq2eVKbu7tZiYn5ylW6yzJXFetS5z4MA+JYaSBaG2inVYDEEqqMIkb17TyWxxziUDieg==",
+      "requires": {
+        "@sentry/hub": "5.8.0",
+        "@sentry/minimal": "5.8.0",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/electron": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-1.0.0.tgz",
+      "integrity": "sha512-Xp4KkDN8I/YVYURzRRiB9hZxkpseVByoml5pa+tIz2HcssDAzmNcpyTlyaBYyGEqJhAIFIDmbBj5t3Qk3pbOzw==",
+      "requires": {
+        "@sentry/browser": "~5.7.1",
+        "@sentry/core": "~5.7.1",
+        "@sentry/minimal": "~5.7.1",
+        "@sentry/node": "~5.7.1",
+        "@sentry/types": "~5.7.1",
+        "@sentry/utils": "~5.7.1",
+        "electron-fetch": "1.3.0",
+        "form-data": "2.3.2",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "@sentry/browser": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.7.1.tgz",
+          "integrity": "sha512-K0x1XhsHS8PPdtlVOLrKZyYvi5Vexs9WApdd214bO6KaGF296gJvH1mG8XOY0+7aA5i2A7T3ttcaJNDYS49lzw==",
+          "requires": {
+            "@sentry/core": "5.7.1",
+            "@sentry/types": "5.7.1",
+            "@sentry/utils": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/core": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",
+          "integrity": "sha512-AOn3k3uVWh2VyajcHbV9Ta4ieDIeLckfo7UMLM+CTk2kt7C89SayDGayJMSsIrsZlL4qxBoLB9QY4W2FgAGJrg==",
+          "requires": {
+            "@sentry/hub": "5.7.1",
+            "@sentry/minimal": "5.7.1",
+            "@sentry/types": "5.7.1",
+            "@sentry/utils": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.7.1.tgz",
+          "integrity": "sha512-evGh323WR073WSBCg/RkhlUmCQyzU0xzBzCZPscvcoy5hd4SsLE6t9Zin+WACHB9JFsRQIDwNDn+D+pj3yKsig==",
+          "requires": {
+            "@sentry/types": "5.7.1",
+            "@sentry/utils": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.7.1.tgz",
+          "integrity": "sha512-nS/Dg+jWAZtcxQW8wKbkkw4dYvF6uyY/vDiz/jFCaux0LX0uhgXAC9gMOJmgJ/tYBLJ64l0ca5LzpZa7BMJQ0g==",
+          "requires": {
+            "@sentry/hub": "5.7.1",
+            "@sentry/types": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/utils": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.7.1.tgz",
+          "integrity": "sha512-nhirUKj/qFLsR1i9kJ5BRvNyzdx/E2vorIsukuDrbo8e3iZ11JMgCOVrmC8Eq9YkHBqgwX4UnrPumjFyvGMZ2Q==",
+          "requires": {
+            "@sentry/types": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.8.0.tgz",
+      "integrity": "sha512-VdApn1ZCNwH1wwQwoO6pu53PM/qgHG+DQege0hbByluImpLBhAj9w50nXnF/8KzV4UoMIVbzCb6jXzMRmqqp9A==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.8.0.tgz",
+      "integrity": "sha512-MIlFOgd+JvAUrBBmq7vr9ovRH1HvckhnwzHdoUPpKRBN+rQgTyZy1o6+kA2fASCbrRqFCP+Zk7EHMACKg8DpIw==",
+      "requires": {
+        "@sentry/hub": "5.8.0",
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.7.1.tgz",
+      "integrity": "sha512-hVM10asFStrOhYZzMqFM7V1lrHkr1ydc2n/SFG0ZmIQxfTjCVElyXV/BJASIdqadM1fFIvvtD/EfgkTcZmub1g==",
+      "requires": {
+        "@sentry/core": "5.7.1",
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^3.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",
+          "integrity": "sha512-AOn3k3uVWh2VyajcHbV9Ta4ieDIeLckfo7UMLM+CTk2kt7C89SayDGayJMSsIrsZlL4qxBoLB9QY4W2FgAGJrg==",
+          "requires": {
+            "@sentry/hub": "5.7.1",
+            "@sentry/minimal": "5.7.1",
+            "@sentry/types": "5.7.1",
+            "@sentry/utils": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.7.1.tgz",
+          "integrity": "sha512-evGh323WR073WSBCg/RkhlUmCQyzU0xzBzCZPscvcoy5hd4SsLE6t9Zin+WACHB9JFsRQIDwNDn+D+pj3yKsig==",
+          "requires": {
+            "@sentry/types": "5.7.1",
+            "@sentry/utils": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.7.1.tgz",
+          "integrity": "sha512-nS/Dg+jWAZtcxQW8wKbkkw4dYvF6uyY/vDiz/jFCaux0LX0uhgXAC9gMOJmgJ/tYBLJ64l0ca5LzpZa7BMJQ0g==",
+          "requires": {
+            "@sentry/hub": "5.7.1",
+            "@sentry/types": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/utils": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.7.1.tgz",
+          "integrity": "sha512-nhirUKj/qFLsR1i9kJ5BRvNyzdx/E2vorIsukuDrbo8e3iZ11JMgCOVrmC8Eq9YkHBqgwX4UnrPumjFyvGMZ2Q==",
+          "requires": {
+            "@sentry/types": "5.7.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
+      "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.8.0.tgz",
+      "integrity": "sha512-KDxUvBSYi0/dHMdunbxAxD3389pcQioLtcO6CI6zt/nJXeVFolix66cRraeQvqupdLhvOk/el649W4fCPayTHw==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1957,6 +2165,14 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
           "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         }
+      }
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -5426,6 +5642,14 @@
         }
       }
     },
+    "electron-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.3.0.tgz",
+      "integrity": "sha512-WzHnWZqKdiCKHqqHu+GphezoWRSUVH6BQ/f13vu16VwYKJRZNt2dUrx40eZJcyZcDGn6RJDTAHS6jVoHoglgNw==",
+      "requires": {
+        "encoding": "^0.1.12"
+      }
+    },
     "electron-is-dev": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
@@ -5591,6 +5815,19 @@
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "es6-symbol": {
@@ -7137,6 +7374,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "hyphenate-style-name": {
       "version": "1.0.3",
@@ -9245,6 +9501,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -8,6 +8,8 @@
     "@material-ui/styles": "^4.5.2",
     "@microsoft/signalr": "^3.0.1",
     "@microsoft/signalr-protocol-msgpack": "^3.0.0",
+    "@sentry/browser": "^5.9.1",
+    "@sentry/electron": "^1.0.0",
     "axios": "^0.19.0",
     "axios-observable": "^1.1.2",
     "clsx": "^1.0.4",
@@ -40,7 +42,7 @@
     "uuid": "^3.3.3",
     "yup": "^0.27.0"
   },
-  "main": "public/electron.js",
+  "main": "public/electron.ts",
   "homepage": "./",
   "scripts": {
     "react-start": "react-scripts start",

--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -42,7 +42,7 @@
     "uuid": "^3.3.3",
     "yup": "^0.27.0"
   },
-  "main": "public/electron.ts",
+  "main": "public/electron.js",
   "homepage": "./",
   "scripts": {
     "react-start": "react-scripts start",

--- a/ExilenceNextApp/public/electron.js
+++ b/ExilenceNextApp/public/electron.js
@@ -7,9 +7,11 @@ const url = require('url');
 const isDev = require('electron-is-dev');
 const sentry = require('@sentry/electron');
 
-sentry.init({
-  dsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156'
-});
+if (!isDev) {
+  sentry.init({
+    dsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156'
+  });
+}
 
 const installExtensions = async () => {
   const installer = require('electron-devtools-installer');
@@ -29,7 +31,6 @@ require('update-electron-app')({
 });
 
 function createWindow() {
-
   const size = electron.screen.getPrimaryDisplay().workAreaSize;
 
   mainWindow = new BrowserWindow({

--- a/ExilenceNextApp/public/electron.ts
+++ b/ExilenceNextApp/public/electron.ts
@@ -5,11 +5,16 @@ const BrowserWindow = electron.BrowserWindow;
 const path = require('path');
 const url = require('url');
 const isDev = require('electron-is-dev');
+const sentry = require('@sentry/electron');
+
+sentry.init({
+  dsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156'
+});
 
 const installExtensions = async () => {
   const installer = require('electron-devtools-installer');
   const forceDownload = isDev;
-  const extensions = ['REACT_DEVELOPER_TOOLS']; 
+  const extensions = ['REACT_DEVELOPER_TOOLS'];
 
   return Promise.all(
     extensions.map(name => installer.default(installer[name], forceDownload))
@@ -24,6 +29,7 @@ require('update-electron-app')({
 });
 
 function createWindow() {
+
   const size = electron.screen.getPrimaryDisplay().workAreaSize;
 
   mainWindow = new BrowserWindow({

--- a/ExilenceNextApp/src/config/app.config.dev.ts
+++ b/ExilenceNextApp/src/config/app.config.dev.ts
@@ -1,5 +1,6 @@
 const devConfig = {
     production: false,
+    sentryBrowserDsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156',
     i18nUrl: '/i18n/{{lng}}/{{ns}}.json'
 };
 

--- a/ExilenceNextApp/src/config/app.config.prod.ts
+++ b/ExilenceNextApp/src/config/app.config.prod.ts
@@ -2,6 +2,7 @@ import { electronService } from "../services/electron.service";
 
 const prodConfig = {
     production: true,
+    sentryBrowserDsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156',
     i18nUrl: electronService.remote.app.getAppPath() + '/../../public/i18n/{{lng}}/{{ns}}.json'
 };
 

--- a/ExilenceNextApp/src/config/sentry.ts
+++ b/ExilenceNextApp/src/config/sentry.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+function initSentry() {
+  Sentry.init({
+    dsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156'
+  });
+}
+
+export default initSentry;

--- a/ExilenceNextApp/src/config/sentry.ts
+++ b/ExilenceNextApp/src/config/sentry.ts
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/browser';
+import AppConfig from './app.config';
 
 function initSentry() {
   Sentry.init({
-    dsn: 'https://e69c936836334a2c9e4b553f20d1d51c@sentry.io/1843156'
+    dsn: AppConfig.sentryBrowserDsn
   });
 }
 

--- a/ExilenceNextApp/src/index.tsx
+++ b/ExilenceNextApp/src/index.tsx
@@ -26,7 +26,9 @@ import { SignalrStore } from './store/signalrStore';
 import { UiStateStore } from './store/uiStateStore';
 import { SnackbarProvider } from 'notistack';
 import Settings from './routes/settings/Settings';
+import initSentry from './config/sentry';
 
+initSentry();
 enableLogging();
 configureI18n();
 


### PR DESCRIPTION
Added crash reporting with sentry.io to both the main process of Electron and the renderer process (React). Currently there is no good way to share configs between these two, so we have to maintain one dsn-key in each process.

Currently using a private account, which we should replace with the official Exilence sentry login later on.

Fixes #99 