### PR TITLE
Upgraded formik to 2.0

### DIFF
--- a/ExilenceNextApp/package-lock.json
+++ b/ExilenceNextApp/package-lock.json
@@ -4817,15 +4817,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-context": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-      "requires": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
-      }
-    },
     "cross-env": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
@@ -5295,6 +5286,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -6882,35 +6878,6 @@
         "bser": "2.1.1"
       }
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
-    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -7104,25 +7071,28 @@
       }
     },
     "formik": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.8.tgz",
-      "integrity": "sha512-fNvPe+ddbh+7xiByT25vuso2p2hseG/Yvuj211fV1DbCjljUEG9OpgRpcb7g7O3kxHX/q31cbZDzMxJXPWSNwA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.0.8.tgz",
+      "integrity": "sha512-PxC9G6EvLdJzMv7z+bsvpI/Euplv2vVgTQebD5yNza4t3fiMBB+iD90VOVTLCyH5Pnv3bljsZiKsIqGp/UNKKg==",
       "requires": {
-        "create-react-context": "^0.2.2",
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.14",
         "lodash-es": "^4.17.14",
-        "prop-types": "^15.6.1",
         "react-fast-compare": "^2.0.1",
+        "scheduler": "^0.17.0",
         "tiny-warning": "^1.0.2",
-        "tslib": "^1.9.3"
+        "tslib": "^1.10.0"
       },
       "dependencies": {
-        "deepmerge": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+        "scheduler": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+          "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
         }
       }
     },
@@ -8350,15 +8320,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -8848,7 +8809,8 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
@@ -10561,15 +10523,6 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -15262,11 +15215,6 @@
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
       "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -22,7 +22,7 @@
     "eslint-config-airbnb": "^18.0.1",
     "eslint-plugin-react": "^7.15.0",
     "export-to-csv": "^0.2.1",
-    "formik": "^1.5.8",
+    "formik": "^2.0.8",
     "i18next": "^17.2.0",
     "i18next-xhr-backend": "^3.2.0",
     "localforage": "^1.7.3",

--- a/ExilenceNextApp/src/components/item-table/item-table-filter/ItemTableFilter.tsx
+++ b/ExilenceNextApp/src/components/item-table/item-table-filter/ItemTableFilter.tsx
@@ -35,7 +35,8 @@ const ItemTableFilter: React.FC<TableFilterProps<IPricedItem>> = (
         searchText: Yup.string().max(20)
       })}
     >
-      {formProps => {
+      {/* todo: refactor and use new formik */}
+      {(formProps: any) => {
         const { values, handleChange } = formProps;
 
         return (

--- a/ExilenceNextApp/src/components/league-selection-form/LeagueSelectionForm.tsx
+++ b/ExilenceNextApp/src/components/league-selection-form/LeagueSelectionForm.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@material-ui/core';
-import { Formik, FormikActions } from 'formik';
+import { Formik } from 'formik';
 import { observer } from 'mobx-react';
 import React, { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,10 +10,9 @@ import error from '../../utils/validation.utils';
 import LeagueDropdown from '../league-dropdown/LeagueDropdown';
 import PriceLeagueDropdown from '../price-league-dropdown/PriceLeagueDropdown';
 
-
 interface LeagueSelectionFormProps {
   handleLeagueSubmit: () => void;
-  handleLeagueChange: (event: ChangeEvent<{ value: unknown; }>) => void;
+  handleLeagueChange: (event: ChangeEvent<{ value: unknown }>) => void;
   styles: Record<string, string>;
   selectedLeague?: string;
   selectedPriceLeague?: string;
@@ -38,10 +37,7 @@ const LeagueSelectionForm: React.FC<LeagueSelectionFormProps> = (
         league: props.selectedLeague,
         priceLeague: props.selectedPriceLeague
       }}
-      onSubmit={(
-        values: LeagueFormValues,
-        { setSubmitting }: FormikActions<LeagueFormValues>
-      ) => {
+      onSubmit={() => {
         props.handleLeagueSubmit();
       }}
       validationSchema={Yup.object().shape({
@@ -49,7 +45,8 @@ const LeagueSelectionForm: React.FC<LeagueSelectionFormProps> = (
         priceLeague: Yup.string().required('Required')
       })}
     >
-      {formProps => {
+      {/* todo: refactor and use new formik */}
+      {(formProps: any) => {
         const {
           values,
           touched,

--- a/ExilenceNextApp/src/components/login-content/account-validation-form/AccountValidationForm.tsx
+++ b/ExilenceNextApp/src/components/login-content/account-validation-form/AccountValidationForm.tsx
@@ -10,7 +10,7 @@ import {
   Link,
   Grid
 } from '@material-ui/core';
-import { Formik, FormikActions } from 'formik';
+import { Formik } from 'formik';
 import { observer } from 'mobx-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -71,10 +71,7 @@ const AccountValidationForm: React.FC<AccountValidationFormProps> = (
           accountName: props.account.name,
           sessionId: props.account.sessionId
         }}
-        onSubmit={(
-          values: AccountFormValues,
-          { setSubmitting }: FormikActions<AccountFormValues>
-        ) => {
+        onSubmit={(values: AccountFormValues) => {
           props.handleValidate({
             name: values.accountName,
             sessionId: values.sessionId
@@ -85,7 +82,8 @@ const AccountValidationForm: React.FC<AccountValidationFormProps> = (
           sessionId: Yup.string().required('Required')
         })}
       >
-        {formProps => {
+        {/* todo: refactor and use new formik */}
+        {(formProps: any) => {
           const {
             values,
             touched,

--- a/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
+++ b/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
@@ -4,7 +4,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { Formik, FormikActions } from 'formik';
+import { Formik } from 'formik';
 import React, { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
@@ -29,9 +29,9 @@ interface ProfileDialogProps {
   stashTabIds: string[];
   characters: Character[];
   handleClickClose: () => void;
-  handleLeagueChange: (event: ChangeEvent<{ value: unknown; }>) => void;
+  handleLeagueChange: (event: ChangeEvent<{ value: unknown }>) => void;
   handleSubmit: (values: ProfileFormValues) => void;
-  handleStashTabChange: (event: ChangeEvent<{ value: unknown; }>) => void;
+  handleStashTabChange: (event: ChangeEvent<{ value: unknown }>) => void;
 }
 
 export interface ProfileFormValues {
@@ -80,10 +80,7 @@ const ProfileDialog: React.FC<ProfileDialogProps> = (
               priceLeague: props.priceLeagueUuid,
               stashTabIds: props.stashTabIds
             }}
-            onSubmit={(
-              values: ProfileFormValues,
-              { setSubmitting }: FormikActions<ProfileFormValues>
-            ) => {
+            onSubmit={(values: ProfileFormValues) => {
               props.handleSubmit(values);
             }}
             validationSchema={Yup.object().shape({
@@ -92,7 +89,8 @@ const ProfileDialog: React.FC<ProfileDialogProps> = (
               priceLeague: Yup.string().required('Required')
             })}
           >
-            {formProps => {
+            {/* todo: refactor and use new formik */}
+            {(formProps: any) => {
               const {
                 values,
                 touched,
@@ -158,7 +156,11 @@ const ProfileDialog: React.FC<ProfileDialogProps> = (
                       variant="contained"
                       type="submit"
                       color="primary"
-                      disabled={noCharacters.length > 0 || props.stashTabIds.length === 0 || (dirty && !isValid)}
+                      disabled={
+                        noCharacters.length > 0 ||
+                        props.stashTabIds.length === 0 ||
+                        (dirty && !isValid)
+                      }
                     >
                       {props.isEditing
                         ? t('action.save_profile')


### PR DESCRIPTION
Upgraded formik to 2.0. We can now create fields using the new `useField` hook. We should aim to convert all current forms, and refactor these components entirely before the app grows larger.

Important: You will need to run `npm i` after this PR has been merged, to update formik.

Will create separate issues for refactoring.

Fixes #68 