### PR TITLE
Added translations for sucess.{x}.leave_group

### DIFF
--- a/ExilenceNextApp/public/i18n/en/notification.json
+++ b/ExilenceNextApp/public/i18n/en/notification.json
@@ -28,7 +28,8 @@
       "change_profile_for_connection": "Successfully changed profile for connection",
       "remove_profile_from_connection": "Successfully removed profile for connection",
       "add_profile_to_connection": "Successfully added profile to connection",
-      "remove_all_snapshots_for_connection": "Successfully cleared snapshots for connection"
+      "remove_all_snapshots_for_connection": "Successfully cleared snapshots for connection",
+      "leave_group": "Sucessfully left group"
     },
     "description": {
       "init_session": "A new session was successfully initiated",
@@ -58,7 +59,8 @@
       "change_profile_for_connection": "Successfully changed profile for connection",
       "remove_profile_from_connection": "Successfully removed profile for connection",
       "add_profile_to_connection": "Successfully added profile to connection",
-      "remove_all_snapshots_for_connection": "Successfully cleared snapshots for connection"
+      "remove_all_snapshots_for_connection": "Successfully cleared snapshots for connection",
+      "leave_group": "Sucessfully left the group"
     }
   },
   "error": {


### PR DESCRIPTION
Added translation for the following

> sucess.description.leave_group
> sucess.title.leave_group

Ticket/Issue reference:
https://github.com/viktorgullmark/exilence-next/issues/485