### PR TITLE
Make all PoE URL's configurable. Change OAuth redirect to non-80 port.

### DIFF
--- a/ExilenceNextApp/src/config/app.config.dev.ts
+++ b/ExilenceNextApp/src/config/app.config.dev.ts
@@ -3,7 +3,12 @@ const devConfig = {
   production: false,
   sentryBrowserDsn: undefined,
   i18nUrl: '/i18n/{{lng}}/{{ns}}.json',
-  trackingId: ''
+  trackingId: '',
+  redirectUrl: 'http://localhost:65535',
+  oauthUrl: 'https://www.pathofexile.com',
+  pathOfExileUrl: 'https://www.pathofexile.com',
+  pathOfExileApiUrl: 'https://api.pathofexile.com',
+  pathOfExileCookieDomain: '.pathofexile.com'
 };
 
 export default devConfig;

--- a/ExilenceNextApp/src/config/app.config.prod.ts
+++ b/ExilenceNextApp/src/config/app.config.prod.ts
@@ -8,7 +8,12 @@ const prodConfig = {
   i18nUrl:
     electronService.remote.app.getAppPath() +
     '/../../public/i18n/{{lng}}/{{ns}}.json',
-  trackingId: 'UA-154599999-2'
+  trackingId: 'UA-154599999-2',
+  redirectUrl: 'http://localhost:65535',
+  oauthUrl: 'https://www.pathofexile.com',
+  pathOfExileUrl: 'https://www.pathofexile.com',
+  pathOfExileApiUrl: 'https://api.pathofexile.com',
+  pathOfExileCookieDomain: '.pathofexile.com'
 };
 
 export default prodConfig;

--- a/ExilenceNextApp/src/config/sentry.ts
+++ b/ExilenceNextApp/src/config/sentry.ts
@@ -7,7 +7,7 @@ function initSentry() {
       dsn: AppConfig.sentryBrowserDsn,
       ignoreErrors: [
         '/(?<=^|\\s)net::\\w+/',
-        'https://www.pathofexile.com',
+        AppConfig.pathOfExileUrl,
         'Network Error',
         'NetworkError',
       ]

--- a/ExilenceNextApp/src/services/auth.service.ts
+++ b/ExilenceNextApp/src/services/auth.service.ts
@@ -42,7 +42,7 @@ function getAuthCookie(): Observable<any> {
 function removeAuthCookie(): Observable<any> {
   return from(
     electronService.remote.session.defaultSession!.cookies.remove(
-      'https://www.pathofexile.com',
+      AppConfig.pathOfExileUrl,
       'POESESSID'
     )
   );

--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -26,8 +26,8 @@ import { rootStore } from '..';
 import { ICharacterWithItems } from '../interfaces/character-with-items.interface';
 
 const rateLimiter = new RateLimiter(5, 10000);
-const poeUrl = 'https://www.pathofexile.com';
-const apiUrl = 'https://api.pathofexile.com';
+const poeUrl = AppConfig.pathOfExileUrl;
+const apiUrl = AppConfig.pathOfExileApiUrl;
 
 export const externalService = {
   getLatestRelease,

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -23,6 +23,7 @@ import { getCharacterLeagues } from '../utils/league.utils';
 import { electronService } from './../services/electron.service';
 import { Account } from './domains/account';
 import { RootStore } from './rootStore';
+import AppConfig from "../config/app.config";
 
 export class AccountStore {
   @persist('list', Account) @observable accounts: Account[] = [];
@@ -107,7 +108,7 @@ export class AccountStore {
     var options = {
       clientId: 'exilence',
       scopes: ['profile'], // Scopes limit access for OAuth tokens.
-      redirectUrl: 'http://localhost',
+      redirectUrl: AppConfig.redirectUrl,
       state: 'yourstate',
       responseType: 'code'
     };
@@ -125,7 +126,7 @@ export class AccountStore {
       alwaysOnTop: true
     });
 
-    var authUrl = `https://www.pathofexile.com/oauth/authorize?client_id=${options.clientId}&response_type=${options.responseType}&scope=${options.scopes}&state=${options.state}&redirect_uri=${options.redirectUrl}`;
+    var authUrl = `${AppConfig.oauthUrl}/oauth/authorize?client_id=${options.clientId}&response_type=${options.responseType}&scope=${options.scopes}&state=${options.state}&redirect_uri=${options.redirectUrl}`;
 
     authWindow.webContents.on('will-redirect', (event: any, url: any) => {
       this.handleAuthCallback(url, authWindow);

--- a/ExilenceNextApp/src/utils/cookie.utils.ts
+++ b/ExilenceNextApp/src/utils/cookie.utils.ts
@@ -1,11 +1,12 @@
 import { ICookie } from '../interfaces/cookie.interface';
+import AppConfig from './../config/app.config';
 
 export function constructCookie(sessionId: string): ICookie {
   const cookie: ICookie = {
-    url: 'https://www.pathofexile.com',
+    url: AppConfig.pathOfExileUrl,
     name: 'POESESSID',
     value: sessionId,
-    domain: '.pathofexile.com',
+    domain: AppConfig.pathOfExileCookieDomain,
     path: '/',
     secure: true,
     expirationDate: 2550873600


### PR DESCRIPTION
Make all PoE URL's configurable to allow for external seamless API mocking.

Change OAuth redirect to non-80 port in case there is a service listening and redirect catch fails.
