### PR TITLE
Added stack treshold setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [0.3.7] - NOT RELEASED
 ##### Added
-- Added missing translations
+- Added a setting for selecting the cutoff for stacks of items, similar to the price treshold but for the total item count
+    - Maximum value for the setting is capped at 5000 c
 - Added a fallback to 'Standard' league for profiles where the pricing league was outdated
     - Previously we didnt update these profiles, so they would fail when snapshotting
+- Added missing translations
+##### Changed
+- Minor improvements to the layout of the settings page
 ##### Fixed
 - Fixed a bug where the app would crash if you pressed enter while having the search bar in focus (thanks to romankrru)
 

--- a/ExilenceNextApp/public/i18n/en/common.json
+++ b/ExilenceNextApp/public/i18n/en/common.json
@@ -102,6 +102,7 @@
     "hour_suffix": "/ h",
     "low_confidence_pricing": "Activate low confidence pricing",
     "price_treshold": "Select price treshold",
+    "total_price_treshold": "Select total price treshold",
     "requires_snapshot_info": "* = requires a new snapshot to take effect",
     "fetch_snapshot_spinner_title": "Fetching snapshots",
     "initiating_session_spinner_title": "Initiating session",
@@ -118,12 +119,14 @@
     "none": "None",
     "low_confidence_pricing": "Low confidence",
     "price_treshold": "Price treshold",
+    "total_price_treshold": "Total price treshold",
     "auto_snapshotting": "Auto snapshotting",
     "auto_snapshot_interval": "Snapshotting interval"
   },
   "helper_text": {
     "low_confidence_pricing": "Includes prices with less than 10 listings",
     "price_treshold": "Sets the cutoff for including items",
+    "total_price_treshold": "Sets the cutoff for including stacks of items",
     "auto_snapshotting": "Handles snapshotting for you at set intervals",
     "auto_snapshot_interval": "Sets the interval for auto snapshotting",
     "ui_scale": "Sets the UI scale"

--- a/ExilenceNextApp/src/components/settings-tabs/net-worth-settings/NetWorthSettings.tsx
+++ b/ExilenceNextApp/src/components/settings-tabs/net-worth-settings/NetWorthSettings.tsx
@@ -7,19 +7,23 @@ import NumberInputSetting from '../number-input-setting/NumberInputSetting';
 interface Props {
   lowConfidencePricing: boolean;
   priceTreshold: number;
+  totalPriceTreshold: number;
   setLowConfidencePricing: (value: boolean) => void;
   setPriceTreshold: (value: number) => void;
+  setTotalPriceTreshold: (value: number) => void;
 }
 
 const NetWorthSettings: React.FC<Props> = ({
   lowConfidencePricing,
   priceTreshold,
+  totalPriceTreshold,
   setLowConfidencePricing,
   setPriceTreshold,
+  setTotalPriceTreshold
 }: Props) => {
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} sm={4}>
+    <Grid container spacing={5}>
+      <Grid item>
         <CheckboxSetting
           value={lowConfidencePricing}
           handleChange={setLowConfidencePricing}
@@ -27,13 +31,24 @@ const NetWorthSettings: React.FC<Props> = ({
           requiresSnapshot
         />
       </Grid>
-      <Grid item xs={12} sm={4}>
+      <Grid item>
         <NumberInputSetting
           value={priceTreshold}
           handleChange={(value: number) => setPriceTreshold(value)}
           translationKey="price_treshold"
           minimum={0}
           maximum={100}
+          suffixKey="unit.chaos"
+          requiresSnapshot
+        />
+      </Grid>
+      <Grid item>
+        <NumberInputSetting
+          value={totalPriceTreshold}
+          handleChange={(value: number) => setTotalPriceTreshold(value)}
+          translationKey="total_price_treshold"
+          minimum={0}
+          maximum={5000}
           suffixKey="unit.chaos"
           requiresSnapshot
         />

--- a/ExilenceNextApp/src/components/settings-tabs/net-worth-settings/NetWorthSettingsContainer.tsx
+++ b/ExilenceNextApp/src/components/settings-tabs/net-worth-settings/NetWorthSettingsContainer.tsx
@@ -14,7 +14,9 @@ const NetWorthSettingsContainer: React.FC<Props> = ({
     <NetWorthSettings
       lowConfidencePricing={settingStore!.lowConfidencePricing}
       priceTreshold={settingStore!.priceTreshold}
+      totalPriceTreshold={settingStore!.totalPriceTreshold}
       setPriceTreshold={(value: number) => settingStore!.setPriceTreshold(value)}
+      setTotalPriceTreshold={(value: number) => settingStore!.setTotalPriceTreshold(value)}
       setLowConfidencePricing={(value: boolean) => settingStore!.setLowConfidencePricing(value)}
     />
   );

--- a/ExilenceNextApp/src/components/settings-tabs/snapshot-settings/SnapshotSettings.tsx
+++ b/ExilenceNextApp/src/components/settings-tabs/snapshot-settings/SnapshotSettings.tsx
@@ -18,15 +18,15 @@ const SnapshotSettings: React.FC<Props> = ({
   setAutoSnapshotInterval,
 }: Props) => {
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} sm={4}>
+    <Grid container spacing={5}>
+      <Grid item>
         <CheckboxSetting
           value={autoSnapshotting}
           handleChange={setAutoSnapshotting}
           translationKey='auto_snapshotting'
         />
       </Grid>
-      <Grid item xs={12} sm={4}>
+      <Grid item>
         <NumberInputSetting
           value={autoSnapshotInterval / 1000 / 60}
           handleChange={setAutoSnapshotInterval}

--- a/ExilenceNextApp/src/components/settings-tabs/ui-settings/UiSettings.tsx
+++ b/ExilenceNextApp/src/components/settings-tabs/ui-settings/UiSettings.tsx
@@ -14,8 +14,8 @@ const UiSettings: React.FC<Props> = ({
 }: Props) => {
 
   return (
-    <Grid container spacing={2}>   
-      <Grid item xs={12} sm={3}>
+    <Grid container spacing={5}>   
+      <Grid item>
         <SliderSetting value={uiScale} handleChange={setUiScale} waitForMouseUp translationKey={'ui_scale'} />
       </Grid>
     </Grid>

--- a/ExilenceNextApp/src/store/settingStore.ts
+++ b/ExilenceNextApp/src/store/settingStore.ts
@@ -7,6 +7,7 @@ export class SettingStore {
   @persist @observable lowConfidencePricing: boolean = false;
   @persist @observable autoSnapshotting: boolean = true;
   @persist @observable priceTreshold: number = 0;
+  @persist @observable totalPriceTreshold: number = 0;
   @persist @observable autoSnapshotInterval: number = 60 * 2 * 1000; // default to 2 minutes
   @persist
   @observable
@@ -44,6 +45,11 @@ export class SettingStore {
   @action
   setPriceTreshold(value: number) {
     this.priceTreshold = value;
+  }
+
+  @action
+  setTotalPriceTreshold(value: number) {
+    this.totalPriceTreshold = value;
   }
 
   @action


### PR DESCRIPTION
Had to add some logic for merging the item stacks before the snapshot finishes, since we normally do this when displaying the items only, not in the actual snapshot process. But in order to know the total stack value, we had to do this here as well.

Closes #414 