### PR TITLE
fixed path to translation files in production build

### DIFF
--- a/ExilenceNextApp/src/config/i18n.ts
+++ b/ExilenceNextApp/src/config/i18n.ts
@@ -10,7 +10,7 @@ const url = require('url');
 function getTranslationPath(lng: string, ns: string) {
   const langPath = `/i18n/${lng}/${ns}.json`;
   const fullPath = url.format({
-    pathname: path.join(electronService.appPath, `/../../../../public${langPath}`),
+    pathname: path.join(electronService.appPath, langPath),
     protocol: 'file:',
     slashes: true,
   });


### PR DESCRIPTION
I tested it locally, on Linux. Before this change, the strings would load correctly when running a test build (npm start), but would fail to load when creating a production build (npm run build for example).
After the change, both builds seem to display text correctly.