### PR TITLE
fix application and tray icon in MacOS

### DIFF
--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -136,6 +136,9 @@
     },
     "win": {
       "icon": "build/icon.ico"
+    },
+    "mac": {
+      "icon": "build/tray.jpg"
     }
   }
 }


### PR DESCRIPTION
Mac builds would previously use the default electron icon.
Now, the Exilence icon is used as both the application and tray icon.
"/build/tray.jpg" was used because a size of min 512x512 is *required*.