### PR TITLE
fix 'npm install' instructions in readme and devel notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Before submitting a PR, please see our [contributing guidelines](https://github.
 Run the following to get started with the client:
 
 ```
-if (npm < 7.x) npm install
-if (npm >=7.x) npm install --legacy-peer-deps (flag needed temporarily)
+npm install
 npm start (to serve the project)
 npm run release (optional, to build the installer for production)
 ```
+NOTE: Running a build using node versions newer than v14 seem to fail on MacOS and Linux. For development on these platforms, it's recommended to use v14.16.1 (Latest LTS).
 
 ## Contact us
 


### PR DESCRIPTION
--legacy-peer-deps doesn't seem to be required anymore.
Adds a note with suggestions on Linux/MacOS dev environment.