### PR TITLE
feat(csv): add hour and minute marks to exported csv file name

### DIFF
--- a/ExilenceNextApp/src/utils/export.utils.ts
+++ b/ExilenceNextApp/src/utils/export.utils.ts
@@ -11,7 +11,7 @@ export function exportData<T>(data: T[], documentTitle: string = 'Export') {
     title: `Data from ${moment(Date.now()).format('YYYY-MM-DD HH:MM')}`,
     useBom: true,
     useKeysAsHeaders: true,
-    filename: `${documentTitle}_${moment(Date.now()).format('YYYY-MM-DD')}`,
+    filename: `${documentTitle}_${moment(Date.now()).format('YYYY-MM-DD-HH-MM')}`,
   };
 
   const csvExporter = new ExportToCsv(options);


### PR DESCRIPTION
Feature request:
`I'm creating a Power Query Tool that Imports the exported .csv and it would be a HUGE help if you could add in the Time or a unique identifier along with the export. So I can export the data multiple times a day.`