### PR TITLE
fix(profile): filter royale league

### DIFF
--- a/ExilenceNextApp/public/i18n/en/common.json
+++ b/ExilenceNextApp/public/i18n/en/common.json
@@ -152,7 +152,7 @@
     "support_us": "Support Us",
     "reset_to_default": "Reset to default",
     "enable_hardware_acceleration": "Enable Hardware Acceleration",
-    "new_character_no_league_in_pricing_league": "Newly created character and can't see the league it's in? Refresh Exilence (ctrl + r)."
+    "new_character_no_league_in_pricing_league": "Newly created character and can't see the league it's in? Refresh Exilence Next (ctrl + r)."
   },
   "value": {
     "none": "None",

--- a/ExilenceNextApp/public/i18n/en/common.json
+++ b/ExilenceNextApp/public/i18n/en/common.json
@@ -151,7 +151,8 @@
     "feature_request": "Feature Request",
     "support_us": "Support Us",
     "reset_to_default": "Reset to default",
-    "enable_hardware_acceleration": "Enable Hardware Acceleration"
+    "enable_hardware_acceleration": "Enable Hardware Acceleration",
+    "new_character_no_league_in_pricing_league": "Newly created character and can't see the league it's in? Refresh Exilence (ctrl + r)."
   },
   "value": {
     "none": "None",

--- a/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.styles.ts
+++ b/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.styles.ts
@@ -6,12 +6,7 @@ const useStyles = makeStyles(() => ({
   },
   icon: {
     alignSelf: 'center',
-  },
-  pricingLeagueHelper: {
-    margin: 0,
-    marginTop: 5,
-    color: '#ffc107',
-  },
+  }
 }));
 
 export default useStyles;

--- a/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.styles.ts
+++ b/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.styles.ts
@@ -4,6 +4,14 @@ const useStyles = makeStyles(() => ({
   small: {
     fontSize: '0.875rem',
   },
+  icon: {
+    alignSelf: 'center',
+  },
+  pricingLeagueHelper: {
+    margin: 0,
+    marginTop: 5,
+    color: '#ffc107',
+  },
 }));
 
 export default useStyles;

--- a/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.tsx
+++ b/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.tsx
@@ -1,4 +1,14 @@
-import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@material-ui/core';
+import {
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Grid,
+  Tooltip,
+  IconButton,
+} from '@material-ui/core';
+import { HelpOutline } from '@material-ui/icons';
 import clsx from 'clsx';
 import { FormikErrors, FormikTouched } from 'formik';
 import { observer } from 'mobx-react-lite';
@@ -48,27 +58,41 @@ const PriceLeagueDropdown = ({
         >
           {t('label.select_price_league')}
         </InputLabel>
-        <Select
-          fullWidth
-          labelWidth={141} // FIXME not sure why labelwidth is sometimes reset to 0 when using useLabelWidth
-          value={values.priceLeague}
-          onChange={(e) => handleChange(e)}
-          classes={{
-            root: size === 'small' ? classes.small : undefined,
-          }}
-          inputProps={{
-            name: 'priceLeague',
-            id: 'price-league-table-dd',
-          }}
-        >
-          {priceLeagues.map((priceLeague: League) => {
-            return (
-              <MenuItem key={priceLeague.uuid} value={priceLeague.id}>
-                {priceLeague.id}
-              </MenuItem>
-            );
-          })}
-        </Select>
+        <Grid container>
+          <Grid item xs={11}>
+            <Select
+              fullWidth
+              labelWidth={141} // FIXME not sure why labelwidth is sometimes reset to 0 when using useLabelWidth
+              value={values.priceLeague}
+              onChange={(e) => handleChange(e)}
+              classes={{
+                root: size === 'small' ? classes.small : undefined,
+              }}
+              inputProps={{
+                name: 'priceLeague',
+                id: 'price-league-table-dd',
+              }}
+            >
+              {priceLeagues.map((priceLeague: League) => {
+                return (
+                  <MenuItem key={priceLeague.uuid} value={priceLeague.id}>
+                    {priceLeague.id}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </Grid>
+          <Grid item xs={1} className={classes.icon}>
+            <Tooltip
+              placement="bottom-end"
+              title={<span>{t('label.new_character_no_league_in_pricing_league')}</span>}
+            >
+              <IconButton>
+                <HelpOutline />
+              </IconButton>
+            </Tooltip>
+          </Grid>
+        </Grid>
         {touched.priceLeague && errors.priceLeague && (
           <FormHelperText error>
             {errors.priceLeague && touched.priceLeague && errors.priceLeague}

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -210,6 +210,7 @@ export class AccountStore {
             concatMap((requests) => {
               const leagues: ILeague[] = requests[0].data;
               const characters: ICharacter[] = requests[1].data;
+              const unsupportedLeagues = ['Path of Exile: Royale'];
 
               if (leagues.length === 0) {
                 throw new Error('error:no_leagues');
@@ -218,10 +219,18 @@ export class AccountStore {
                 throw new Error('error:no_characters');
               }
 
-              this.rootStore.leagueStore.updateLeagues(getCharacterLeagues(characters));
-              this.rootStore.leagueStore.updatePriceLeagues(
-                leagues.filter((l) => l.id.indexOf('SSF') === -1)
+              const accountLeagues = leagues.filter((league) =>
+                characters.find((character) =>
+                  character.league.toLowerCase().includes(league.id.toLowerCase())
+                )
               );
+              const filteredLeagues = accountLeagues.filter(
+                (league) =>
+                  !unsupportedLeagues.includes(league.id) && league.id.indexOf('SSF') === -1
+              );
+
+              this.rootStore.leagueStore.updateLeagues(getCharacterLeagues(characters));
+              this.rootStore.leagueStore.updatePriceLeagues(filteredLeagues);
               this.getSelectedAccount.updateAccountLeagues(characters);
               this.getSelectedAccount.updateLeaguesForProfiles(
                 leagues.concat(getCharacterLeagues(characters)).map((l) => l.id)


### PR DESCRIPTION
Fixes `404` errors that users see at the app initialization due to PoE Royale league introduction. 
Also limits the amount of requests that are being made to the amount of leagues PoE account has characters in.

![image](https://user-images.githubusercontent.com/19862545/127779252-36169a5b-772f-4145-abe4-e440e2361df9.png)
