### PR TITLE
Features/item filtering regex

### DIFF
--- a/ExilenceNextApp/src/utils/snapshot.utils.ts
+++ b/ExilenceNextApp/src/utils/snapshot.utils.ts
@@ -125,6 +125,8 @@ export const filterItems = (snapshots: IApiSnapshot[]) => {
 
   const rarity = getRarityIdentifier(filterText);
 
+  const itemNameRegex = new RegExp(filterText, 'i');
+
   return mergeItemStacks(
     snapshots
       .flatMap((sts) =>
@@ -144,7 +146,8 @@ export const filterItems = (snapshots: IApiSnapshot[]) => {
                 .join(', ')
                 .toLowerCase()
                 .includes(filterText)) ||
-            (i.calculated > 0 && rarity >= 0 && i.frameType === rarity)
+            (i.calculated > 0 && rarity >= 0 && i.frameType === rarity) ||
+            itemNameRegex.test(i.name)
         )
       )
   );

--- a/ExilenceNextApp/src/utils/snapshot.utils.ts
+++ b/ExilenceNextApp/src/utils/snapshot.utils.ts
@@ -125,7 +125,13 @@ export const filterItems = (snapshots: IApiSnapshot[]) => {
 
   const rarity = getRarityIdentifier(filterText);
 
-  const itemNameRegex = new RegExp(filterText, 'i');
+  let itemNameRegex = new RegExp('', 'i');
+  try {
+    // try/catch required because of filtering being an onChange event, example: typing only [ would lead to a SyntaxError
+    itemNameRegex = new RegExp(filterText, 'i');
+  } catch (error) {
+    console.error(error);
+  }
 
   return mergeItemStacks(
     snapshots


### PR DESCRIPTION
Added filtering items based on item names using Regex.

After trying to only filter out Shrieking and Deafening essences out of my essence tab and seeing that regex wasn't an option I figured it would be a nice addition to Exilence Next.

This uses JavaScripts' built-in [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).

Showcase: ![image](https://user-images.githubusercontent.com/43404517/129206795-8be9d28d-a290-44bb-870f-45e677c94663.png)

