### PR TITLE
fix(protocol): move protocol defining back to instance handling

### DIFF
--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -152,7 +152,7 @@
       "category": "Utility"
     },
     "protocols": {
-      "name": "exilence-next",
+      "name": "exilence",
       "schemes": [
         "exilence"
       ]

--- a/ExilenceNextApp/public/electron.js
+++ b/ExilenceNextApp/public/electron.js
@@ -165,6 +165,12 @@ function createWindow() {
   }
 }
 
+if (isDev && process.platform !== 'darwin') {
+  app.setAsDefaultProtocolClient('exilence', process.execPath, [path.resolve(process.argv[1])]);
+} else {
+  app.setAsDefaultProtocolClient('exilence');
+}
+
 /**
  * App Listeners
  */
@@ -198,14 +204,6 @@ if (!gotTheLock) {
     await createWindow();
     await createTray(trayProps);
     await checkForUpdates();
-
-    if(!app.isDefaultProtocolClient('exilence')) {
-      if (isDev && process.platform !== 'darwin') {
-        app.setAsDefaultProtocolClient('exilence', process.execPath, [path.resolve(process.argv[1])]);
-      } else {
-        app.setAsDefaultProtocolClient('exilence');
-      }
-    }
   });
 
   app.on('activate', async () => {

--- a/ExilenceNextApp/public/electron.js
+++ b/ExilenceNextApp/public/electron.js
@@ -47,15 +47,6 @@ createNetWorthOverlay();
  * Main Window
  */
 function createWindow() {
-
-  if(!app.isDefaultProtocolClient('exilence')) {
-    if (process.platform !== 'darwin') {
-      app.setAsDefaultProtocolClient('exilence', process.execPath, [path.resolve(process.argv[1])]);
-    } else {
-      app.setAsDefaultProtocolClient('exilence');
-    }
-  }
-
   const minMainWindowWidth = 800;
   const minMainWindowHeight = 800;
   const { width: defaultWidth, height: defaultHeight } = screen.getPrimaryDisplay().workAreaSize;
@@ -207,6 +198,14 @@ if (!gotTheLock) {
     await createWindow();
     await createTray(trayProps);
     await checkForUpdates();
+
+    if(!app.isDefaultProtocolClient('exilence')) {
+      if (isDev && process.platform !== 'darwin') {
+        app.setAsDefaultProtocolClient('exilence', process.execPath, [path.resolve(process.argv[1])]);
+      } else {
+        app.setAsDefaultProtocolClient('exilence');
+      }
+    }
   });
 
   app.on('activate', async () => {


### PR DESCRIPTION
Added `isDev` flag to `app.setAsDefaultProtocolClient('exilence', process.execPath, [path.resolve(process.argv[1])]);` and moved protocol handling after window is created

Potentially fixes https://github.com/viktorgullmark/exilence-next/issues/710