### PR TITLE
feat(account): add console support

### DIFF
--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -92,7 +92,7 @@ function getItemsForTabs(tabs: IStashTab[], account: string, league: string, rea
 function getLeagues(
   type: string = 'main',
   compact: number = 1,
-  realm?: string
+  realm: string = 'pc'
 ): Observable<AxiosResponse<ILeague[]>> {
   const parameters = `?type=${type}&compact=${compact}${getRealmParam(realm)}`;
   return rateLimiter.limit(
@@ -102,7 +102,7 @@ function getLeagues(
 
 function getCharacters(realm?: string): Observable<AxiosResponse<ICharacter[]>> {
   // todo: create util for this realm segment
-  const parameters = `${getRealmParam(realm)}`;
+  const parameters = `?realm=${realm}`;
 
   return rateLimiter.limit(
     axios.get<ICharacter[]>(poeUrl + '/character-window/get-characters' + parameters)
@@ -122,7 +122,7 @@ function getCharacterItems(
 }
 
 function getProfile(realm?: string): Observable<AxiosResponse<IPoeProfile>> {
-  const parameters = `${getRealmParam(realm)}`;
+  const parameters = `?realm=${realm}`;
 
   return rateLimiter.limit(axios.get<IPoeProfile>(apiUrl + '/profile' + parameters));
 }

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -202,9 +202,10 @@ export class AccountStore {
         concatMap((res: IPoeProfile) => {
           const account = this.addOrUpdateAccount(res.name);
           this.selectAccountByName(account.name!);
+          console.log({account});
           return forkJoin(
-            externalService.getLeagues(),
-            externalService.getCharacters(),
+            externalService.getLeagues('main', 1, res.realm),
+            externalService.getCharacters(res.realm),
             !skipAuth ? this.getSelectedAccount.authorize() : of({})
           ).pipe(
             concatMap((requests) => {


### PR DESCRIPTION
Fixes lack of `realm` param when we select `PlayStation` or `xbox` in login view.

Tested personally on all platforms and didn't find any issues regarding that.

However, since xbox and PS accounts were both new, if we don't have any characters in the account then we can't sign out (well we can reset the data in the settings so there is a workaround).