### PR TITLE
feat(networth+misc): option to display net worth in exalted orbs and misc bugfixes

### DIFF
--- a/ExilenceNextApp/public/i18n/en/common.json
+++ b/ExilenceNextApp/public/i18n/en/common.json
@@ -18,7 +18,8 @@
     "leave_group": "Leave group",
     "save_custom_price": "Save",
     "lets_begin": "Lets begin!",
-    "apply_filter": "Apply filter"
+    "apply_filter": "Apply filter",
+    "currency_switch": "Click to switch currency"
   },
   "title": {
     "login": "Login",

--- a/ExilenceNextApp/public/i18n/en/common.json
+++ b/ExilenceNextApp/public/i18n/en/common.json
@@ -56,7 +56,7 @@
     "reset_indexeddb": "Reset Data"
   },
   "label": {
-    "no_prices_retrieved": "Waiting for prices",
+    "no_prices_retrieved": "No prices fetched for `{{league}}`, you can change pricing league in your profile",
     "customize_prices": "Customize prices",
     "set_custom_price": "Set custom price",
     "remove_custom_price": "Remove custom price",

--- a/ExilenceNextApp/public/i18n/en/common.json
+++ b/ExilenceNextApp/public/i18n/en/common.json
@@ -127,6 +127,7 @@
     "not_available": "N/A",
     "hour_suffix": "/ h",
     "low_confidence_pricing": "Activate low confidence pricing",
+    "price_in_exalt": "Display prices in Exalted Orbs",
     "price_threshold": "Price threshold",
     "total_price_threshold": "Total price threshold",
     "requires_snapshot_info": "* = requires a new snapshot to take effect",
@@ -194,6 +195,7 @@
   "value": {
     "none": "None",
     "low_confidence_pricing": "Low confidence",
+    "price_in_exalt": "Prices in exalted",
     "price_threshold": "Price threshold",
     "total_price_threshold": "Total price threshold",
     "auto_snapshotting": "Auto snapshotting",
@@ -202,6 +204,7 @@
   },
   "helper_text": {
     "low_confidence_pricing": "Includes prices with less than 10 listings",
+    "price_in_exalt": "Displays prices and values in exalt instead of chaos",
     "price_threshold": "Sets the cutoff for including items",
     "total_price_threshold": "Sets the cutoff for including total stack of items",
     "auto_snapshotting": "Handles snapshotting for you at set intervals",

--- a/ExilenceNextApp/public/main/overlays/netWorth.html
+++ b/ExilenceNextApp/public/main/overlays/netWorth.html
@@ -74,7 +74,7 @@
             }
 
             .net-worth {
-                color: rgb(214, 182, 0);
+                color: #AD904B;
             }
 
             .secondary-text {
@@ -126,8 +126,8 @@
 
             ipcRenderer.on('overlayUpdate', (event, window) => {
                 if (window.event === 'netWorth') {
-                    netWorthElement.innerText = +window.data.netWorth.toFixed(2) + ' c';
-                    incomeElement.innerText = window.data.income ? window.data.income : '0 c';
+                    netWorthElement.innerText = +window.data.netWorth.toFixed(2) + ` ${window.data.short}`;
+                    incomeElement.innerText = window.data.income ? window.data.income : `0 ${window.data.short}`;
                 }
             })
 

--- a/ExilenceNextApp/src/components/item-table/item-table-filter-subtotal/ItemTableFilterSubtotal.tsx
+++ b/ExilenceNextApp/src/components/item-table/item-table-filter-subtotal/ItemTableFilterSubtotal.tsx
@@ -19,8 +19,12 @@ const ItemTableFilterSubtotal = ({ array }: ItemTableFilterSubtotalProps) => {
 
   let value = array.map((i) => i.total).reduce((a, b) => a + b, 0);
 
-  if (settingStore.showPriceInExalt && priceStore.exaltedPrice) {
-    value = value / priceStore.exaltedPrice;
+  if (settingStore.showPriceInExalt) {
+    if (priceStore.exaltedPrice) {
+      value = value / priceStore.exaltedPrice;
+    } else {
+      value = 0;
+    }
   }
 
   // FIXME: remove unnecessary .map()

--- a/ExilenceNextApp/src/components/item-table/item-table-filter-subtotal/ItemTableFilterSubtotal.tsx
+++ b/ExilenceNextApp/src/components/item-table/item-table-filter-subtotal/ItemTableFilterSubtotal.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Paper } from '@material-ui/core';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
-
-import { itemColors } from '../../../assets/themes/exilence-theme';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useStores } from '../../..';
+import { rarityColors } from '../../../assets/themes/exilence-theme';
 import { IPricedItem } from '../../../interfaces/priced-item.interface';
 import useStyles from './ItemTableFilterSubtotal.styles';
 
@@ -15,22 +15,28 @@ type ItemTableFilterSubtotalProps = {
 const ItemTableFilterSubtotal = ({ array }: ItemTableFilterSubtotalProps) => {
   const { t } = useTranslation();
   const classes = useStyles();
+  const { priceStore, settingStore } = useStores();
+
+  let value = array.map((i) => i.total).reduce((a, b) => a + b, 0);
+
+  if (settingStore.showPriceInExalt && priceStore.exaltedPrice) {
+    value = value / priceStore.exaltedPrice;
+  }
 
   // FIXME: remove unnecessary .map()
   const sumString =
     ' ' +
-    array
-      .map((i) => i.total)
-      .reduce((a, b) => a + b, 0)
-      .toLocaleString(undefined, {
-        maximumFractionDigits: 2,
-        minimumFractionDigits: 2,
-      });
+    value.toLocaleString(undefined, {
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2,
+    });
 
   return (
     <Paper className={clsx(classes.paper)}>
       {t('label.filter_total')}
-      <span style={{ color: itemColors.chaosOrb }}>&nbsp;{sumString} c </span>
+      <span style={{ color: rarityColors.currency }}>
+        &nbsp;{sumString} {settingStore.activeCurrency.short}
+      </span>
     </Paper>
   );
 };

--- a/ExilenceNextApp/src/components/overview-widget-content/OverviewWidgetContent.styles.ts
+++ b/ExilenceNextApp/src/components/overview-widget-content/OverviewWidgetContent.styles.ts
@@ -19,6 +19,10 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     textAlign: 'right',
   },
+  adornmentIcon: {
+    marginLeft: theme.spacing(0.75),
+    color: primaryLighter,
+  },
   title: {
     fontSize: '0.8rem',
   },

--- a/ExilenceNextApp/src/components/overview-widget-content/OverviewWidgetContent.tsx
+++ b/ExilenceNextApp/src/components/overview-widget-content/OverviewWidgetContent.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Box, Grid, Tooltip, Typography } from '@material-ui/core';
+import { Box, Grid, IconButton, Tooltip, Typography } from '@material-ui/core';
+import { Clear, SwapHoriz } from '@material-ui/icons';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
-
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useStores } from '../..';
 import { formatValue } from '../../utils/snapshot.utils';
 import useStyles from './OverviewWidgetContent.styles';
 
@@ -21,6 +22,7 @@ type OverviewWidgetContentProps = {
   currency?: boolean;
   currencyShort?: string;
   tooltip?: string;
+  currencySwitch?: boolean;
 };
 
 const OverviewWidgetContent = ({
@@ -37,9 +39,11 @@ const OverviewWidgetContent = ({
   currency,
   currencyShort,
   tooltip = '',
+  currencySwitch,
 }: OverviewWidgetContentProps) => {
   const classes = useStyles();
   const { t } = useTranslation();
+  const { settingStore, priceStore } = useStores();
   return (
     <>
       <Grid container className={classes.topContent}>
@@ -50,7 +54,40 @@ const OverviewWidgetContent = ({
           <div className={classes.ellipsis}>
             <Typography variant="h6" align="right" style={{ color: valueColor }}>
               {currency ? `${formatValue(value, currencyShort, valueIsDiff, true)}` : value}
+              {currency && currencySwitch && (
+                <Tooltip
+                  title={
+                    <>
+                      <Typography variant="subtitle1" color="inherit" gutterBottom>
+                        1 ex = {priceStore.exaltedPrice?.toFixed(1)} chaos
+                      </Typography>
+                      <em>{t('action.currency_switch')}</em>
+                    </>
+                  }
+                  classes={{ tooltip: classes.tooltip }}
+                  placement="bottom-end"
+                >
+                  <IconButton
+                    size="small"
+                    className={classes.adornmentIcon}
+                    onClick={() => settingStore.setShowPriceInExalt(!settingStore.showPriceInExalt)}
+                  >
+                    <SwapHoriz />
+                  </IconButton>
+                </Tooltip>
+              )}
               <span className={classes.valueSuffix}>{valueSuffix}</span>
+              {clearFn && (
+                <Tooltip
+                  title={`${t('label.reset')}`}
+                  classes={{ tooltip: classes.tooltip }}
+                  placement="bottom-end"
+                >
+                  <IconButton size="small" className={classes.adornmentIcon} onClick={clearFn}>
+                    <Clear />
+                  </IconButton>
+                </Tooltip>
+              )}
             </Typography>
           </div>
         </Grid>
@@ -90,11 +127,6 @@ const OverviewWidgetContent = ({
                     >
                       {secondaryValue !== 0 ? secondaryValue : ''}
                     </Typography>
-                    {!secondaryValue && clearFn && (
-                      <a className={classes.inlineLink} onClick={clearFn}>
-                        {t('label.reset')}
-                      </a>
-                    )}
                   </>
                 )}
               </div>

--- a/ExilenceNextApp/src/components/overview-widget-content/OverviewWidgetContent.tsx
+++ b/ExilenceNextApp/src/components/overview-widget-content/OverviewWidgetContent.tsx
@@ -53,7 +53,15 @@ const OverviewWidgetContent = ({
         <Grid item sm={9}>
           <div className={classes.ellipsis}>
             <Typography variant="h6" align="right" style={{ color: valueColor }}>
-              {currency ? `${formatValue(value, currencyShort, valueIsDiff, true)}` : value}
+              {currency
+                ? `${formatValue(
+                    value,
+                    currencyShort,
+                    valueIsDiff,
+                    true,
+                    !priceStore.exaltedPrice
+                  )}`
+                : value}
               {currency && currencySwitch && (
                 <Tooltip
                   title={

--- a/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.tsx
+++ b/ExilenceNextApp/src/components/price-league-dropdown/PriceLeagueDropdown.tsx
@@ -27,6 +27,7 @@ type PriceLeagueDropdownProps = {
   size?: 'small' | 'medium';
   margin?: 'dense' | 'normal';
   required?: boolean;
+  helperIcon?: boolean;
 };
 
 const PriceLeagueDropdown = ({
@@ -38,6 +39,7 @@ const PriceLeagueDropdown = ({
   size = 'medium',
   margin = 'normal',
   required = true,
+  helperIcon,
 }: PriceLeagueDropdownProps) => {
   const { t } = useTranslation();
   const classes = useStyles();
@@ -59,7 +61,7 @@ const PriceLeagueDropdown = ({
           {t('label.select_price_league')}
         </InputLabel>
         <Grid container>
-          <Grid item xs={11}>
+          <Grid item xs={helperIcon ? 11 : 12}>
             <Select
               fullWidth
               labelWidth={141} // FIXME not sure why labelwidth is sometimes reset to 0 when using useLabelWidth
@@ -82,16 +84,18 @@ const PriceLeagueDropdown = ({
               })}
             </Select>
           </Grid>
-          <Grid item xs={1} className={classes.icon}>
-            <Tooltip
-              placement="bottom-end"
-              title={<span>{t('label.new_character_no_league_in_pricing_league')}</span>}
-            >
-              <IconButton>
-                <HelpOutline />
-              </IconButton>
-            </Tooltip>
-          </Grid>
+          {helperIcon && (
+            <Grid item xs={1} className={classes.icon}>
+              <Tooltip
+                placement="bottom-end"
+                title={<span>{t('label.new_character_no_league_in_pricing_league')}</span>}
+              >
+                <IconButton>
+                  <HelpOutline />
+                </IconButton>
+              </Tooltip>
+            </Grid>
+          )}
         </Grid>
         {touched.priceLeague && errors.priceLeague && (
           <FormHelperText error>

--- a/ExilenceNextApp/src/components/price-table/PriceTableContainer.tsx
+++ b/ExilenceNextApp/src/components/price-table/PriceTableContainer.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const PriceTableContainer = () => {
   const { uiStateStore, priceStore } = useStores();
   const classes = useStyles();
-  const prices = priceStore!.pricesWithCustomValues;
+  const prices = priceStore!.customPricesTableData;
   const data = useMemo(() => {
     return excludeLegacyMaps(prices ? prices : []);
   }, [prices]);

--- a/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
+++ b/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
@@ -150,6 +150,7 @@ const ProfileDialog = ({
                   errors={errors}
                   handleChange={handleChange}
                   values={values}
+                  helperIcon
                 />
                 <LeagueDropdown
                   leagues={leagues}

--- a/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
+++ b/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
@@ -150,7 +150,6 @@ const ProfileDialog = ({
                   errors={errors}
                   handleChange={handleChange}
                   values={values}
-                  helperIcon
                 />
                 <LeagueDropdown
                   leagues={leagues}

--- a/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
+++ b/ExilenceNextApp/src/components/profile-dialog/ProfileDialog.tsx
@@ -181,6 +181,7 @@ const ProfileDialog = ({
                         label: c.name,
                       } as ISelectOption;
                     })}
+                    hasPlaceholder
                   />
                   <CheckboxField
                     name="includeEquipment"

--- a/ExilenceNextApp/src/components/settings-tabs/general/net-worth-settings/NetWorthSettings.tsx
+++ b/ExilenceNextApp/src/components/settings-tabs/general/net-worth-settings/NetWorthSettings.tsx
@@ -11,6 +11,13 @@ const NetWorthSettings = () => {
     <Grid container spacing={5}>
       <Grid item>
         <CheckboxSetting
+          value={settingStore!.showPriceInExalt}
+          handleChange={(value: boolean) => settingStore!.setShowPriceInExalt(value)}
+          translationKey="price_in_exalt"
+        />
+      </Grid>
+      <Grid item>
+        <CheckboxSetting
           value={settingStore!.lowConfidencePricing}
           handleChange={(value: boolean) => settingStore!.setLowConfidencePricing(value)}
           translationKey="low_confidence_pricing"

--- a/ExilenceNextApp/src/components/toolbar/Toolbar.tsx
+++ b/ExilenceNextApp/src/components/toolbar/Toolbar.tsx
@@ -122,7 +122,9 @@ const Toolbar = ({
           )}
           {signalrOnline && !hasPrices && (
             <WarningIcon
-              titleAccess={t('label.no_prices_retrieved')}
+              titleAccess={t('label.no_prices_retrieved', {
+                league: activeProfile?.activePriceLeagueId,
+              })}
               className={classes.offlineIcon}
             />
           )}

--- a/ExilenceNextApp/src/components/toolbar/ToolbarContainer.tsx
+++ b/ExilenceNextApp/src/components/toolbar/ToolbarContainer.tsx
@@ -51,7 +51,8 @@ const ToolbarContainer = () => {
         ? signalrStore!.activeGroup.income
         : accountStore!.getSelectedAccount!.activeProfile!.income,
       activeCurrency().short,
-      true
+      true,
+      !priceStore.exaltedPrice
     );
 
     const netWorth = signalrStore!.activeGroup
@@ -133,7 +134,7 @@ const ToolbarContainer = () => {
       />
       <Toolbar
         hasPrices={
-          priceStore!.pricesWithCustomValues && priceStore!.pricesWithCustomValues.length > 0
+          priceStore!.customPricesTableData && priceStore!.customPricesTableData.length > 0
         }
         changingProfile={uiStateStore!.changingProfile}
         signalrOnline={signalrStore!.online}

--- a/ExilenceNextApp/src/components/toolbar/ToolbarContainer.tsx
+++ b/ExilenceNextApp/src/components/toolbar/ToolbarContainer.tsx
@@ -38,8 +38,8 @@ const ToolbarContainer = () => {
   };
 
   const activeCurrency = () => {
-    return accountStore!.getSelectedAccount!.activeProfile!
-      ? accountStore!.getSelectedAccount!.activeProfile!.activeCurrency
+    return settingStore?.showPriceInExalt
+      ? { name: 'exalted', short: 'ex' }
       : { name: 'chaos', short: 'c' };
   };
 

--- a/ExilenceNextApp/src/components/toolbar/ToolbarContainer.tsx
+++ b/ExilenceNextApp/src/components/toolbar/ToolbarContainer.tsx
@@ -60,7 +60,7 @@ const ToolbarContainer = () => {
 
     overlayStore!.createOverlay({
       event: 'netWorth',
-      data: { netWorth: netWorth, income: income },
+      data: { netWorth: netWorth, income: income, short: settingStore.activeCurrency.short },
     });
   };
 

--- a/ExilenceNextApp/src/routes/net-worth/NetWorth.tsx
+++ b/ExilenceNextApp/src/routes/net-worth/NetWorth.tsx
@@ -10,7 +10,7 @@ import { observer } from 'mobx-react-lite';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { appName, useStores, visitor } from '../..';
-import { itemColors } from '../../assets/themes/exilence-theme';
+import { rarityColors } from '../../assets/themes/exilence-theme';
 import ChartToolboxContainer from '../../components/chart-toolbox/ChartToolboxContainer';
 import {
   ExpansionPanel,
@@ -32,7 +32,7 @@ export const cardHeight = 100;
 export const chartHeight = 240;
 
 const NetWorth = () => {
-  const { accountStore, signalrStore, uiStateStore } = useStores();
+  const { accountStore, signalrStore, uiStateStore, settingStore, priceStore } = useStores();
   const theme = useTheme();
   const activeProfile = accountStore!.getSelectedAccount.activeProfile;
   const { activeGroup } = signalrStore!;
@@ -77,8 +77,11 @@ const NetWorth = () => {
     return activeProfile ? activeProfile.snapshots : [];
   };
 
-  const activeCurrency = () => {
-    return activeProfile ? activeProfile.activeCurrency : { name: 'chaos', short: 'c' };
+  const getExaltedValue = (value: number) => {
+    if (settingStore.showPriceInExalt && priceStore.exaltedPrice) {
+      value = value / priceStore.exaltedPrice;
+    }
+    return value;
   };
 
   useEffect(() => {
@@ -101,8 +104,8 @@ const NetWorth = () => {
               secondaryValueIsDiff
               secondaryValueStyles={{ fontSize: '0.8rem' }}
               title="label.total_value"
-              valueColor={itemColors.chaosOrb}
-              currencyShort={activeCurrency().short}
+              valueColor={rarityColors.currency}
+              currencyShort={settingStore.activeCurrency.short}
               icon={<MonetizationOnIcon fontSize="default" />}
               currency
               tooltip="Change in value between the two latest snapshots"
@@ -112,13 +115,13 @@ const NetWorth = () => {
         <Grid item xs={6} md={3} lg={3} xl={2}>
           <Widget loading={loading()} backgroundColor={theme.palette.secondary.main}>
             <OverviewWidgetContent
-              value={activeGroup ? activeGroup.income : income()}
+              value={activeGroup ? getExaltedValue(activeGroup.income) : getExaltedValue(income())}
               valueIsDiff
               valueSuffix={` ${t('label.hour_suffix')}`}
               title="label.total_income"
-              valueColor={itemColors.chaosOrb}
+              valueColor={rarityColors.currency}
               icon={<TrendingUpIcon fontSize="default" />}
-              currencyShort={activeCurrency().short}
+              currencyShort={settingStore.activeCurrency.short}
               currency
               clearFn={activeGroup ? undefined : () => activeProfile?.clearIncome()}
             />

--- a/ExilenceNextApp/src/routes/net-worth/NetWorth.tsx
+++ b/ExilenceNextApp/src/routes/net-worth/NetWorth.tsx
@@ -109,6 +109,7 @@ const NetWorth = () => {
               icon={<MonetizationOnIcon fontSize="default" />}
               currency
               tooltip="Change in value between the two latest snapshots"
+              currencySwitch
             />
           </Widget>
         </Grid>

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -232,18 +232,12 @@ export class AccountStore {
                 throw new Error('error:no_characters');
               }
 
-              const accountLeagues = leagues.filter((league) =>
-                characters.find((character) =>
-                  character.league.toLowerCase().includes(league.id.toLowerCase())
-                )
-              );
-              const filteredLeagues = accountLeagues.filter(
+              const filteredPriceLeagues = leagues.filter(
                 (league) =>
                   !unsupportedLeagues.includes(league.id) && league.id.indexOf('SSF') === -1
               );
-
               this.rootStore.leagueStore.updateLeagues(getCharacterLeagues(characters));
-              this.rootStore.leagueStore.updatePriceLeagues(filteredLeagues);
+              this.rootStore.leagueStore.updatePriceLeagues(filteredPriceLeagues);
               this.getSelectedAccount.updateAccountLeagues(characters);
               this.getSelectedAccount.updateLeaguesForProfiles(
                 leagues.concat(getCharacterLeagues(characters)).map((l) => l.id)

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -1,6 +1,6 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import axios from 'axios-observable';
-import { action, computed, makeObservable, observable, runInAction } from 'mobx';
+import { action, autorun, computed, makeObservable, observable, reaction, runInAction } from 'mobx';
 import { persist } from 'mobx-persist';
 import { fromStream } from 'mobx-utils';
 import { forkJoin, of, Subject, throwError, timer } from 'rxjs';
@@ -33,6 +33,14 @@ export class AccountStore {
     makeObservable(this);
     electronService.ipcRenderer.on('auth-callback', (_event, { code, error }) => {
       this.handleAuthCallback(code, error);
+    });
+
+    autorun(() => {
+      if (this.getSelectedAccount?.activeLeague) {
+        rootStore.uiStateStore.setSelectedPriceTableLeagueId(
+          this.getSelectedAccount?.activeLeague.id
+        );
+      }
     });
   }
 

--- a/ExilenceNextApp/src/store/domains/account.ts
+++ b/ExilenceNextApp/src/store/domains/account.ts
@@ -254,7 +254,7 @@ export class Account implements IAccount {
         if (rootStore.signalrStore.activeGroup) {
           rootStore.signalrStore.changeProfileForConnection(
             rootStore.signalrStore.ownConnection.connectionId,
-            mapProfileToApiProfile(foundProfile)
+            mapProfileToApiProfile(foundProfile, rootStore.settingStore.activeCurrency)
           );
         }
         return this.setActiveProfileSuccess();
@@ -369,7 +369,7 @@ export class Account implements IAccount {
 
     newProfile.active = true;
 
-    const apiProfile = mapProfileToApiProfile(newProfile);
+    const apiProfile = mapProfileToApiProfile(newProfile, rootStore.settingStore.activeCurrency);
 
     return rootStore.signalrHub.invokeEvent<IApiProfile>('AddProfile', apiProfile).pipe(
       map((p: IApiProfile) => {
@@ -407,7 +407,7 @@ export class Account implements IAccount {
     if (rootStore.signalrStore.activeGroup) {
       rootStore.signalrStore.addProfileToConnection(
         rootStore.signalrStore.ownConnection.connectionId,
-        mapProfileToApiProfile(p)
+        mapProfileToApiProfile(p, rootStore.settingStore.activeCurrency)
       );
     }
   }

--- a/ExilenceNextApp/src/store/domains/group.ts
+++ b/ExilenceNextApp/src/store/domains/group.ts
@@ -1,6 +1,7 @@
 import { action, computed, makeObservable, observable } from 'mobx';
 import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
+import { rootStore } from '../..';
 
 import { IApiConnection } from '../../interfaces/api/api-connection.interface';
 import { IApiGroup } from '../../interfaces/api/api-group.interface';
@@ -63,12 +64,16 @@ export class Group implements IApiGroup {
       moment(a.created).isBefore(b.created) ? 1 : -1
     )[0];
 
-    const previousNetworth = getValueForSnapshotsTabs(
+    let previousNetworth = getValueForSnapshotsTabs(
       this.latestGroupSnapshotsExceptLast(latestSnapshot.uuid)
     );
 
-    const newNetworth = getValueForSnapshotsTabs(this.latestGroupSnapshots);
+    let newNetworth = getValueForSnapshotsTabs(this.latestGroupSnapshots);
 
+    if (rootStore.settingStore.showPriceInExalt && rootStore.priceStore.exaltedPrice) {
+      newNetworth = newNetworth / rootStore.priceStore.exaltedPrice;
+      previousNetworth = previousNetworth / rootStore.priceStore.exaltedPrice;
+    }
     return newNetworth - previousNetworth;
   }
 
@@ -131,7 +136,11 @@ export class Group implements IApiGroup {
     if (this.latestGroupSnapshots.length === 0) {
       return 0;
     }
-    return calculateNetWorth(this.latestGroupSnapshots);
+    let calculatedValue = calculateNetWorth(this.latestGroupSnapshots);
+    if (rootStore.settingStore.showPriceInExalt && rootStore.priceStore.exaltedPrice) {
+      calculatedValue = calculatedValue / rootStore.priceStore.exaltedPrice;
+    }
+    return calculatedValue;
   }
 
   @computed

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -10,7 +10,6 @@ import { IApiProfile } from '../../interfaces/api/api-profile.interface';
 import { IApiSnapshot } from '../../interfaces/api/api-snapshot.interface';
 import { IChartStashTabSnapshot } from '../../interfaces/chart-stash-tab-snapshot.interface';
 import { IConnectionChartSeries } from '../../interfaces/connection-chart-series.interface';
-import { ICurrency } from '../../interfaces/currency.interface';
 import { IPricedItem } from '../../interfaces/priced-item.interface';
 import { IProfile } from '../../interfaces/profile.interface';
 import { ISnapshot } from '../../interfaces/snapshot.interface';
@@ -41,10 +40,6 @@ export class Profile {
   @persist @observable activeLeagueId: string = '';
   @persist @observable activePriceLeagueId: string = '';
   @persist @observable activeCharacterName: string = '';
-  @persist('object') @observable activeCurrency: ICurrency = {
-    name: 'chaos',
-    short: 'c',
-  };
 
   @persist('list') @observable activeStashTabIds: string[] = [];
 
@@ -105,7 +100,11 @@ export class Profile {
     if (this.snapshots.length === 0) {
       return 0;
     }
-    return calculateNetWorth([mapSnapshotToApiSnapshot(this.snapshots[0])]);
+    let calculatedValue = calculateNetWorth([mapSnapshotToApiSnapshot(this.snapshots[0])]);
+    if (rootStore.settingStore.showPriceInExalt && rootStore.priceStore.exaltedPrice) {
+      calculatedValue = calculatedValue / rootStore.priceStore.exaltedPrice;
+    }
+    return calculatedValue;
   }
 
   @computed
@@ -113,13 +112,17 @@ export class Profile {
     if (this.snapshots.length < 2) {
       return 0;
     }
-    const lastSnapshotNetWorth = getValueForSnapshotsTabs([
+    let lastSnapshotNetWorth = getValueForSnapshotsTabs([
       mapSnapshotToApiSnapshot(this.snapshots[0]),
     ]);
-    const previousSnapshotNetWorth = getValueForSnapshotsTabs([
+    let previousSnapshotNetWorth = getValueForSnapshotsTabs([
       mapSnapshotToApiSnapshot(this.snapshots[1]),
     ]);
 
+    if (rootStore.settingStore.showPriceInExalt && rootStore.priceStore.exaltedPrice) {
+      lastSnapshotNetWorth = lastSnapshotNetWorth / rootStore.priceStore.exaltedPrice;
+      previousSnapshotNetWorth = previousSnapshotNetWorth / rootStore.priceStore.exaltedPrice;
+    }
     return lastSnapshotNetWorth - previousSnapshotNetWorth;
   }
 
@@ -234,6 +237,7 @@ export class Profile {
       const incomePerHour =
         (calculateNetWorth([lastSnapshot]) - calculateNetWorth([firstSnapshot])) / hoursToCalcOver;
       this.income = incomePerHour;
+
       return;
     }
 
@@ -280,7 +284,10 @@ export class Profile {
   updateProfile(profile: IProfile, callback: () => void) {
     visitor!.event('Profile', 'Edit profile').send();
 
-    const apiProfile = mapProfileToApiProfile(new Profile(profile));
+    const apiProfile = mapProfileToApiProfile(
+      new Profile(profile),
+      rootStore.settingStore.activeCurrency
+    );
 
     fromStream(
       rootStore.signalrHub.invokeEvent<IApiProfile>('EditProfile', apiProfile).pipe(
@@ -330,8 +337,8 @@ export class Profile {
 
   @action
   updateNetWorthOverlay() {
-    const activeCurrency = rootStore.accountStore.getSelectedAccount!.activeProfile!
-      ? rootStore.accountStore.getSelectedAccount!.activeProfile!.activeCurrency
+    const activeCurrency = rootStore.settingStore.showPriceInExalt
+      ? { name: 'exalted', short: 'ex' }
       : { name: 'chaos', short: 'c' };
 
     const income = formatValue(

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -349,6 +349,7 @@ export class Profile {
       true
     );
 
+    console.log(rootStore.settingStore.activeCurrency.short)
     rootStore.overlayStore.updateOverlay({
       event: 'netWorth',
       data: {
@@ -356,6 +357,7 @@ export class Profile {
           ? rootStore.signalrStore.activeGroup.netWorthValue
           : rootStore.accountStore.getSelectedAccount.activeProfile!.netWorthValue,
         income: income,
+        short: rootStore.settingStore.activeCurrency.short,
       },
     });
   }

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -341,22 +341,23 @@ export class Profile {
       ? { name: 'exalted', short: 'ex' }
       : { name: 'chaos', short: 'c' };
 
-    const income = formatValue(
-      rootStore.signalrStore.activeGroup
-        ? rootStore.signalrStore.activeGroup.income
-        : rootStore.accountStore.getSelectedAccount!.activeProfile!.income,
-      activeCurrency.short,
-      true
-    );
+    let income = rootStore.signalrStore.activeGroup
+      ? rootStore.signalrStore.activeGroup.income
+      : rootStore.accountStore.getSelectedAccount!.activeProfile!.income;
 
-    console.log(rootStore.settingStore.activeCurrency.short)
+    if (rootStore.settingStore.showPriceInExalt && rootStore.priceStore.exaltedPrice) {
+      income = income / rootStore.priceStore.exaltedPrice;
+    }
+
+    const formattedIncome = formatValue(income, activeCurrency.short, true);
+
     rootStore.overlayStore.updateOverlay({
       event: 'netWorth',
       data: {
         netWorth: rootStore.signalrStore.activeGroup
           ? rootStore.signalrStore.activeGroup.netWorthValue
           : rootStore.accountStore.getSelectedAccount.activeProfile!.netWorthValue,
-        income: income,
+        income: formattedIncome,
         short: rootStore.settingStore.activeCurrency.short,
       },
     });

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -349,7 +349,12 @@ export class Profile {
       income = income / rootStore.priceStore.exaltedPrice;
     }
 
-    const formattedIncome = formatValue(income, activeCurrency.short, true);
+    const formattedIncome = formatValue(
+      income,
+      activeCurrency.short,
+      true,
+      !rootStore.priceStore.exaltedPrice
+    );
 
     rootStore.overlayStore.updateOverlay({
       event: 'netWorth',

--- a/ExilenceNextApp/src/store/priceStore.ts
+++ b/ExilenceNextApp/src/store/priceStore.ts
@@ -41,6 +41,10 @@ export class PriceStore {
     );
   }
 
+  @computed get exaltedPrice() {
+    return this.pricesWithCustomValues?.find((p) => p.name === 'Exalted Orb')?.calculated;
+  }
+
   @computed get pricesWithCustomValues() {
     const selectedLeagueId = this.rootStore.uiStateStore.selectedPriceTableLeagueId;
     const activeLeagueId = this.rootStore.accountStore.getSelectedAccount.activePriceLeague?.id;

--- a/ExilenceNextApp/src/store/settingStore.ts
+++ b/ExilenceNextApp/src/store/settingStore.ts
@@ -1,5 +1,6 @@
 import { action, computed, makeObservable, observable } from 'mobx';
 import { persist } from 'mobx-persist';
+import { rootStore } from '..';
 import { ICurrency } from '../interfaces/currency.interface';
 
 import { electronService } from '../services/electron.service';
@@ -43,6 +44,7 @@ export class SettingStore {
   @action
   setShowPriceInExalt(value: boolean) {
     this.showPriceInExalt = value;
+    rootStore.accountStore.getSelectedAccount?.activeProfile?.updateNetWorthOverlay();
   }
 
   @action

--- a/ExilenceNextApp/src/store/settingStore.ts
+++ b/ExilenceNextApp/src/store/settingStore.ts
@@ -1,5 +1,6 @@
-import { action, makeObservable, observable } from 'mobx';
+import { action, computed, makeObservable, observable } from 'mobx';
 import { persist } from 'mobx-persist';
+import { ICurrency } from '../interfaces/currency.interface';
 
 import { electronService } from '../services/electron.service';
 import { RootStore } from './rootStore';
@@ -21,6 +22,10 @@ export class SettingStore {
 
   constructor(private rootStore: RootStore) {
     makeObservable(this);
+  }
+
+  @computed get activeCurrency(): ICurrency {
+    return this.showPriceInExalt ? { name: 'exalted', short: 'ex' } : { name: 'chaos', short: 'c' };
   }
 
   @action

--- a/ExilenceNextApp/src/store/settingStore.ts
+++ b/ExilenceNextApp/src/store/settingStore.ts
@@ -11,6 +11,7 @@ export class SettingStore {
     electronService.localSettings?.isHardwareAccelerationEnabled || true;
   @persist @observable priceThreshold: number = 0;
   @persist @observable totalPriceThreshold: number = 0;
+  @persist @observable showPriceInExalt = false;
   @persist @observable autoSnapshotInterval: number = 60 * 2 * 1000; // default to 2 minutes
   @persist
   @observable
@@ -32,6 +33,11 @@ export class SettingStore {
     }
     this.uiScale = factor;
     electronService.webFrame.setZoomFactor(factor / 100);
+  }
+
+  @action
+  setShowPriceInExalt(value: boolean) {
+    this.showPriceInExalt = value;
   }
 
   @action

--- a/ExilenceNextApp/src/utils/profile.utils.ts
+++ b/ExilenceNextApp/src/utils/profile.utils.ts
@@ -1,13 +1,14 @@
 import { IApiProfile } from '../interfaces/api/api-profile.interface';
+import { ICurrency } from '../interfaces/currency.interface';
 import { Profile } from '../store/domains/profile';
 
-export function mapProfileToApiProfile(p: Profile) {
+export function mapProfileToApiProfile(p: Profile, activeCurrency: ICurrency) {
   return {
     uuid: p.uuid,
     name: p.name,
     activeLeagueId: p.activeLeagueId,
     activePriceLeagueId: p.activePriceLeagueId,
-    activeCurrency: p.activeCurrency,
+    activeCurrency: activeCurrency,
     activeStashTabIds: p.activeStashTabIds,
     snapshots: [],
     active: p.active,

--- a/ExilenceNextApp/src/utils/snapshot.utils.ts
+++ b/ExilenceNextApp/src/utils/snapshot.utils.ts
@@ -80,7 +80,8 @@ export const formatValue = (
   value: number | string | undefined,
   suffix: string | undefined,
   change?: boolean,
-  displayZero?: boolean
+  displayZero?: boolean,
+  unavailable?: boolean
 ) => {
   if (!value || typeof value === 'string') {
     return !displayZero ? '' : `0 ${suffix}`;
@@ -93,7 +94,7 @@ export const formatValue = (
 
   valueString = valueString.replace('-', '- ').replace('−', '− ');
 
-  if (value === 0) {
+  if (value === 0 || unavailable) {
     valueString = '0';
   }
 


### PR DESCRIPTION
Option to display net worth in exalted orbs instead of chaos
- [x] Add setting for toggling exalted/chaos display
- [x] Display net worth values in chosen setting (exalted or chaos)
  - [x] Rework colors for net worth display labels
  - [x] Display `Total net worth` in chosen setting
  - [x] Display `Filter total` in chosen setting
  - [x] Display overlay net worth / income in chosen setting
  - [x] Display `0` when exalted price is missing, right now it displays the chaos value in exalts

Misc
- [x] Added placeholder to character selection dropdown
- [x] Fixed a bug where the app would be waiting for prices even when it had prices available
- [x] Updated warning message for `Waiting for prices` to improve clarity
- [x] Reworked income card to match new net worth style
- [x] Now sets the default league for custom prices to the same as your active profile
- [x] Remove help icon for price league dropdown when viewed on the settings page
- [x] Now lists all leagues with prices again. **NOTE: This should not be released until we have caching of ninja prices on our end**