### PR TITLE
feat(maps): reworked map pricing + misc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.6.1] - NOT RELEASED
+## [1.0.0] - NOT RELEASED
 #### Added
 - Added a setting for using exalted orbs as main currency
    - Added quicktoggle button directly on the net worth card
    - Changed the currency color to a more neutral tone
+- Added support for pricing `Blighted` maps
+- Added support for pricing `Elder` maps
+- Added support for pricing `Shaper` maps
+- Added display of map tier in the item table
 - Added a sparkline chart to the net worth card
 - Added beta labels to new features
 - Added a switch in the toolbar for quickly toggling autosnapshotting
 - Added tooltips to menu icons
 - Added placeholder option to character selection dropdown
 #### Fixed
+- Fixed a bug where the icon for some items would sometimes be wrong compared to how it looks in your stash
+- Fixed an issue where some legacy maps were priced incorrectly
 - Fixed a bug where the app would sometimes get stuck on `Waiting for prices`
 - Fixed a bug where the `Waiting for prices` warning would appear when filtering in the custom prices table
 #### Changed
+- Reworked how maps are priced
+  - Should now accurately price maps with good confidence
+  - Now only prices maps based on the latest generation of maps (e.g Expedition)
 - Changed which leagues the pricing league dropdown lists
   - Now lists all leagues that has prices on poe.ninja
 - Changed the warning message for `Waiting for prices` to be more descriptive than previously

--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exilence-next-app",
-  "version": "0.6.1",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",

--- a/ExilenceNextApp/src/components/columns/Columns.tsx
+++ b/ExilenceNextApp/src/components/columns/Columns.tsx
@@ -107,6 +107,23 @@ export function itemCorrupted(options: { accessor: string; header: string }): Co
   };
 }
 
+export function itemIlvlTier(options: {
+  accessor: (row: any) => string | number | null | undefined;
+  header: string;
+}): Column<object> {
+  const { header, accessor } = options;
+
+  return {
+    Header: header,
+    accessor,
+    align: 'right',
+    // eslint-disable-next-line react/display-name
+    Cell: (row: any) => {
+      return <span>{row.value}</span>;
+    },
+  };
+}
+
 export function itemTabs(options: { accessor: string; header: string }): Column<object> {
   const { header, accessor } = options;
 

--- a/ExilenceNextApp/src/components/item-table/ItemTableContainer.tsx
+++ b/ExilenceNextApp/src/components/item-table/ItemTableContainer.tsx
@@ -124,7 +124,6 @@ const ItemTableContainer = ({
   }, [activeGroup]);
 
   const data = useMemo(() => {
-    console.log("table data", getItems);
     return getItems;
   }, [getItems, bulkSellView]);
 

--- a/ExilenceNextApp/src/components/item-table/ItemTableContainer.tsx
+++ b/ExilenceNextApp/src/components/item-table/ItemTableContainer.tsx
@@ -124,6 +124,7 @@ const ItemTableContainer = ({
   }, [activeGroup]);
 
   const data = useMemo(() => {
+    console.log("table data", getItems);
     return getItems;
   }, [getItems, bulkSellView]);
 

--- a/ExilenceNextApp/src/components/item-table/itemTableBulkSellColumns.ts
+++ b/ExilenceNextApp/src/components/item-table/itemTableBulkSellColumns.ts
@@ -1,5 +1,12 @@
 import { Column } from 'react-table';
-import { itemCorrupted, itemIcon, itemLinks, itemName, itemValue } from '../columns/Columns';
+import {
+  itemCorrupted,
+  itemIcon,
+  itemIlvlTier,
+  itemLinks,
+  itemName,
+  itemValue,
+} from '../columns/Columns';
 
 const itemTableBulkSellColumns: Column<object>[] = [
   itemIcon({
@@ -13,11 +20,14 @@ const itemTableBulkSellColumns: Column<object>[] = [
     },
     true
   ),
-  {
-    Header: 'Item level',
-    accessor: 'ilvl',
-    align: 'right',
-  },
+  itemIlvlTier({
+    accessor: (row: any) => (row.tier > 0 ? row.tier : row.ilvl),
+    header: 'Ilvl / Tier',
+  }),
+  itemCorrupted({
+    accessor: 'corrupted',
+    header: 'Corrupted',
+  }),
   itemCorrupted({
     accessor: 'corrupted',
     header: 'Corrupted',

--- a/ExilenceNextApp/src/components/item-table/itemTableColumns.ts
+++ b/ExilenceNextApp/src/components/item-table/itemTableColumns.ts
@@ -2,6 +2,7 @@ import { Column } from 'react-table';
 import {
   itemCorrupted,
   itemIcon,
+  itemIlvlTier,
   itemLinks,
   itemName,
   itemTabs,
@@ -17,11 +18,10 @@ const itemTableColumns: Column<object>[] = [
     accessor: 'name',
     header: 'Name',
   }),
-  {
-    Header: 'Item level',
-    accessor: 'ilvl',
-    align: 'right',
-  },
+  itemIlvlTier({
+    accessor: (row: any) => (row.tier > 0 ? row.tier : row.ilvl),
+    header: 'Ilvl / Tier',
+  }),
   itemTabs({
     accessor: 'tab',
     header: 'Tabs',

--- a/ExilenceNextApp/src/components/item-table/itemTableGroupColumns.ts
+++ b/ExilenceNextApp/src/components/item-table/itemTableGroupColumns.ts
@@ -1,5 +1,12 @@
 import { Column } from 'react-table';
-import { itemCorrupted, itemIcon, itemLinks, itemName, itemValue } from '../columns/Columns';
+import {
+  itemCorrupted,
+  itemIcon,
+  itemIlvlTier,
+  itemLinks,
+  itemName,
+  itemValue,
+} from '../columns/Columns';
 
 const itemTableGroupColumns: Column<object>[] = [
   itemIcon({
@@ -10,11 +17,10 @@ const itemTableGroupColumns: Column<object>[] = [
     accessor: 'name',
     header: 'Name',
   }),
-  {
-    Header: 'Item level',
-    accessor: 'ilvl',
-    align: 'right',
-  },
+  itemIlvlTier({
+    accessor: (row: any) => (row.tier > 0 ? row.tier : row.ilvl),
+    header: 'Ilvl / Tier',
+  }),
   itemCorrupted({
     accessor: 'corrupted',
     header: 'Corrupted',

--- a/ExilenceNextApp/src/components/price-table/priceTableColumns.ts
+++ b/ExilenceNextApp/src/components/price-table/priceTableColumns.ts
@@ -3,6 +3,7 @@ import {
   itemCell,
   itemCorrupted,
   itemIcon,
+  itemIlvlTier,
   itemLinks,
   itemName,
   itemValue,
@@ -17,10 +18,9 @@ const itemTableColumns: Column<object>[] = [
     accessor: 'name',
     header: 'Name',
   }),
-  itemCell({
-    header: 'Item level',
-    accessor: 'ilvl',
-    align: 'right',
+  itemIlvlTier({
+    accessor: (row: any) => (row.tier > 0 ? row.tier : row.ilvl),
+    header: 'Ilvl / Tier',
   }),
   itemCell({
     header: 'Variant',

--- a/ExilenceNextApp/src/interfaces/item.interface.ts
+++ b/ExilenceNextApp/src/interfaces/item.interface.ts
@@ -15,6 +15,7 @@ export interface IItem {
   name: string;
   shaper: boolean;
   elder: boolean;
+  baseType: string;
   fractured: boolean;
   synthesised: boolean;
   typeLine: string;

--- a/ExilenceNextApp/src/interfaces/priced-item.interface.ts
+++ b/ExilenceNextApp/src/interfaces/priced-item.interface.ts
@@ -11,6 +11,7 @@ export interface IPricedItem {
   max: number;
   elder: boolean;
   shaper: boolean;
+  blighted: boolean;
   mean: number;
   median: number;
   min: number;

--- a/ExilenceNextApp/src/services/pricing.service.ts
+++ b/ExilenceNextApp/src/services/pricing.service.ts
@@ -27,9 +27,7 @@ function priceItem(item: IPricedItem, prices: IExternalPrice[]) {
       case 1: // magic
       case 2: // rare
         if (item.name.indexOf(' Map') > -1) {
-          price = prices.find(
-            (p) => (p.name === item.name || item.name.indexOf(p.name) > -1) && p.tier === item.tier
-          );
+          price = prices.find((p) => p.name === item.name && p.tier === item.tier);
         } else {
           // other (e.g fragments, scrabs)
           price = prices.find((p) => p.name === item.name);
@@ -107,6 +105,7 @@ function priceItem(item: IPricedItem, prices: IExternalPrice[]) {
     ...item,
     ...modifiedPrice,
     corrupted: item.corrupted,
+    icon: item.icon,
   };
   return data;
 }

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -166,8 +166,11 @@ export class Profile {
   }
 
   @computed
-  get sparklineChartData(): ISparklineDataPoint[] {
+  get sparklineChartData(): ISparklineDataPoint[] | undefined {
     const snapshots = [...this.snapshots.slice(0, 10)];
+    if (snapshots.length === 0) {
+      return;
+    }
     return snapshots.map((s, i) => {
       return {
         x: i + 1,

--- a/ExilenceNextApp/src/store/priceStore.ts
+++ b/ExilenceNextApp/src/store/priceStore.ts
@@ -1,9 +1,8 @@
 import { AxiosError } from 'axios';
-import { action, computed, makeObservable, observable } from 'mobx';
+import { action, computed, makeObservable, observable, toJS } from 'mobx';
 import { fromStream } from 'mobx-utils';
 import { forkJoin, from, interval, of } from 'rxjs';
 import { catchError, concatMap, map, switchMap } from 'rxjs/operators';
-import { rootStore } from '..';
 import { IExternalPrice } from '../interfaces/external-price.interface';
 import { filterPrices, findPrice } from '../utils/price.utils';
 import { ILeaguePriceSource } from './../interfaces/league-price-source.interface';

--- a/ExilenceNextApp/src/utils/item.utils.ts
+++ b/ExilenceNextApp/src/utils/item.utils.ts
@@ -50,23 +50,26 @@ export function parseTabNames(tabs: ICompactTab[]) {
 
 export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
   return items.map((item: IItem) => {
-    return {
+    const mapTier =
+      item.properties !== null && item.properties !== undefined ? getMapTier(item.properties) : 0;
+    const blighted = item.typeLine.indexOf('Blighted ') > -1;
+    const mappedItem = {
       uuid: uuidv4(),
       itemId: item.id,
-      name: getItemName(item.typeLine, item.name),
+      name: mapTier && item.frameType !== 3 ? item.baseType : getItemName(item.typeLine, item.name),
       typeLine: item.typeLine,
       frameType: item.frameType,
       calculated: 0,
       inventoryId: item.inventoryId,
-      elder: item.elder !== undefined ? item.elder : false,
-      shaper: item.shaper !== undefined ? item.shaper : false,
+      elder: (item.elder !== undefined ? item.elder : false) || isElderMap(item.implicitMods),
+      shaper: (item.shaper !== undefined ? item.shaper : false) || isShaperMap(item.implicitMods),
+      blighted: blighted,
       icon: item.icon,
       ilvl:
         item.typeLine.indexOf(' Seed') > -1 && item.frameType === 5
           ? getSeedTier(item.properties)
           : item.ilvl,
-      tier:
-        item.properties !== null && item.properties !== undefined ? getMapTier(item.properties) : 0,
+      tier: mapTier,
       corrupted: item.corrupted || false,
       links:
         item.sockets !== undefined && item.sockets !== null
@@ -95,6 +98,7 @@ export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
           ]
         : [],
     } as IPricedItem;
+    return mappedItem;
   });
 }
 
@@ -193,6 +197,20 @@ export function getItemName(typeline: string, name: string) {
     itemName += ' ' + typeline;
   }
   return itemName.replace('<<set:MS>><<set:M>><<set:S>>', '').trim();
+}
+
+export function isElderMap(implicitMods: string[]): boolean {
+  if (implicitMods) {
+    return implicitMods.some((im) => im.includes('Elder'));
+  }
+  return false;
+}
+
+export function isShaperMap(implicitMods: string[]): boolean {
+  if (implicitMods) {
+    return implicitMods.some((im) => im.includes('Shaper'));
+  }
+  return false;
 }
 
 export function getItemVariant(sockets: ISocket[], explicitMods: string[], name: string): string {

--- a/ExilenceNextApp/src/utils/price.utils.ts
+++ b/ExilenceNextApp/src/utils/price.utils.ts
@@ -169,6 +169,6 @@ export function mapApiPricedItemToPricedItem(item: IPricedItem) {
 }
 
 export function excludeLegacyMaps(prices: IExternalPrice[]) {
-  const legacyMapVariants = ['Pre 2.0', 'Atlas2', 'Atlas2-3.4'];
-  return prices.filter((p) => !p.variant || !legacyMapVariants.includes(p.variant));
+  const acceptedMaps = [', Gen-11', 'expedition'];
+  return prices.filter((p) => !p.variant || acceptedMaps.includes(p.variant));
 }


### PR DESCRIPTION
Reworked map pricing entirely to now include blighted, elder, shaper and proper tiers. Also increased the accuracy of map pricing and tested it with both Standard and Expedition.

Also went ahead and did some misc fixes as seen in the changelog updates.