### PR TITLE
feat(api): use new pathofexile api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Changed the behaviour of the custom prices table
   - Now uses the active pricing league as default
 - Changed the default setting for autosnapshotting to false
+- Changed the minimum auto snapshotting interval to five minutes, up from two
 - Changed background color of the filter total chip
 - Now only shows the filter total chip when the filter is active
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to this project will be documented in this file.
 - Changed the default setting for autosnapshotting to false
 - Changed the minimum auto snapshotting interval to five minutes, up from two
 - Changed background color of the filter total chip
+- Changed how we set the rate limitation on requests
+  - Now parses the headers from the response and sets/updates them accordingly
 - Now only shows the filter total chip when the filter is active
 #### Removed
 - Removed the helper icon from the pricing league dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.0] - NOT RELEASED
 #### Added
+- Added support for parsing the Unique stash tab
+- Added support for parsing the Map tab
 - Added a setting for using exalted orbs as main currency
    - Added quicktoggle button directly on the net worth card
    - Changed the currency color to a more neutral tone
@@ -29,6 +31,8 @@ All notable changes to this project will be documented in this file.
   - Now only prices maps based on the latest generation of maps (e.g Expedition)
 - Reworked how uniques are priced
   - Should now correctly identify uniques all the time
+- Changed the underlying data provider
+  - Now uses the new https://api.pathofexile.com instead of `/character-window`
 - Changed which leagues the pricing league dropdown lists
   - Now lists all leagues that has prices on poe.ninja
 - Changed the warning message for `Waiting for prices` to be more descriptive than previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added a setting for using exalted orbs as main currency
    - Added quicktoggle button directly on the net worth card
    - Changed the currency color to a more neutral tone
-- Added support for pricing `Blighted` maps
-- Added support for pricing `Elder` maps
-- Added support for pricing `Shaper` maps
+- Added support for pricing `Blighted`, `Elder` and `Shaper` maps
 - Added display of map tier in the item table
 - Added a sparkline chart to the net worth card
 - Added beta labels to new features

--- a/ExilenceNextApp/public/i18n/en/status.json
+++ b/ExilenceNextApp/public/i18n/en/status.json
@@ -6,6 +6,7 @@
     "fetching_characters": "Fetching characters",
     "validating_session": "Validating session",
     "fetching_stash_tab": "Fetching stash tab",
+    "fetching_subtabs": "Fetching special tabs",
     "pricing_items": "Pricing items",
     "saving_snapshot": "Saving snapshot",
     "refreshing_stash_tabs": "Refreshing stash tabs",

--- a/ExilenceNextApp/src/components/profile-dialog/ProfileDialogContainer.tsx
+++ b/ExilenceNextApp/src/components/profile-dialog/ProfileDialogContainer.tsx
@@ -51,11 +51,11 @@ const ProfileDialogContainer = ({
       if (foundLeague && accountLeague) {
         setPriceLeague(getPriceLeagueSelection(isEditing).id);
         setCharacters(accountLeague.characters);
-        setStashTabs(accountLeague.stashtabs);
+        setStashTabs(accountLeague.stashtabList);
 
         if (isEditing) {
           setSelectedStashTabs(
-            accountLeague.stashtabs.filter((s) => profile!.activeStashTabIds.includes(s.id))
+            accountLeague.stashtabList.filter((s) => profile!.activeStashTabIds.includes(s.id))
           );
         }
       }
@@ -95,7 +95,7 @@ const ProfileDialogContainer = ({
     setSelectedStashTabs([]);
 
     if (accountLeague) {
-      setStashTabs(accountLeague.stashtabs);
+      setStashTabs(accountLeague.stashtabList);
       setCharacters(accountLeague.characters);
     } else {
       setStashTabs([]);

--- a/ExilenceNextApp/src/components/settings-tabs/general/snapshot-settings/SnapshotSettings.tsx
+++ b/ExilenceNextApp/src/components/settings-tabs/general/snapshot-settings/SnapshotSettings.tsx
@@ -22,7 +22,7 @@ const SnapshotSettings = () => {
           handleChange={(value: number) => settingStore!.setAutoSnapshotInterval(value)}
           translationKey="auto_snapshot_interval"
           disabled={!settingStore!.autoSnapshotting}
-          minimum={2}
+          minimum={5}
           maximum={1000}
           suffixKey="unit.minute"
         />

--- a/ExilenceNextApp/src/components/stash-tab-dropdown/StashTabDropdown.tsx
+++ b/ExilenceNextApp/src/components/stash-tab-dropdown/StashTabDropdown.tsx
@@ -42,7 +42,6 @@ const StashTabDropdown = ({
 
   const getColour = (id: string) => {
     const foundTab = stashTabs.find((st) => st.id === id);
-    console.log('color', foundTab?.metadata.colour);
     return foundTab ? foundTab.metadata.colour : '';
   };
 

--- a/ExilenceNextApp/src/components/stash-tab-dropdown/StashTabDropdown.tsx
+++ b/ExilenceNextApp/src/components/stash-tab-dropdown/StashTabDropdown.tsx
@@ -1,12 +1,10 @@
-import React, { ChangeEvent, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { Box, Chip, Popper, PopperProps, TextField } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { observer } from 'mobx-react-lite';
-
+import React, { ChangeEvent, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { IStashTab } from '../../interfaces/stash.interface';
-import { rgbToHex } from './../../utils/colour.utils';
 import useStyles from './StashTabDropdown.styles';
 
 type StashTabDropdownProps = {
@@ -44,7 +42,8 @@ const StashTabDropdown = ({
 
   const getColour = (id: string) => {
     const foundTab = stashTabs.find((st) => st.id === id);
-    return foundTab ? rgbToHex(foundTab.colour.r, foundTab.colour.g, foundTab.colour.b) : '';
+    console.log('color', foundTab?.metadata.colour);
+    return foundTab ? foundTab.metadata.colour : '';
   };
 
   useEffect(() => {
@@ -62,7 +61,7 @@ const StashTabDropdown = ({
         style={{ width: width ? width : 'auto' }}
         value={selectedStashTabs}
         defaultValue={defaultValue}
-        getOptionLabel={(option) => option.n}
+        getOptionLabel={(option) => option.name}
         onChange={(e, value) => {
           if (handleChange) {
             handleChange(e);
@@ -75,9 +74,9 @@ const StashTabDropdown = ({
               variant="outlined"
               key={index}
               className={classes.chip}
-              label={option.n}
+              label={option.name}
               classes={{ label: classes.chipLabel }}
-              style={{ border: `2px solid ${getColour(option.id)}` }}
+              style={{ border: `2px solid #${getColour(option.id)}` }}
               {...getTagProps({ index })}
             />
           ))

--- a/ExilenceNextApp/src/interfaces/character-with-items.interface.ts
+++ b/ExilenceNextApp/src/interfaces/character-with-items.interface.ts
@@ -1,7 +1,0 @@
-import { ICharacter } from './character.interface';
-import { IItem } from './item.interface';
-
-export interface ICharacterWithItems {
-  character: ICharacter;
-  items: IItem[];
-}

--- a/ExilenceNextApp/src/interfaces/character.interface.ts
+++ b/ExilenceNextApp/src/interfaces/character.interface.ts
@@ -1,8 +1,16 @@
+import { IItem } from './item.interface';
+
 export interface ICharacter {
+  id: string;
   name: string;
-  league: string;
-  classId: number;
-  ascendancyClass: number;
   class: string;
   level: number;
+  experience: number;
+  league?: string;
+  expired?: boolean;
+  deleted?: boolean;
+  current?: boolean;
+  equipment?: IItem[];
+  inventory?: IItem[];
+  jewels?: IItem[];
 }

--- a/ExilenceNextApp/src/interfaces/character.interface.ts
+++ b/ExilenceNextApp/src/interfaces/character.interface.ts
@@ -1,5 +1,13 @@
 import { IItem } from './item.interface';
 
+export interface ICharacterListResponse {
+  characters: ICharacter[];
+}
+
+export interface ICharacterResponse {
+  character: ICharacter;
+}
+
 export interface ICharacter {
   id: string;
   name: string;

--- a/ExilenceNextApp/src/interfaces/stash.interface.ts
+++ b/ExilenceNextApp/src/interfaces/stash.interface.ts
@@ -15,8 +15,6 @@ export interface IStashTab {
   type: string;
   metadata: IMetaData;
   items?: IItem[];
-  public?: boolean;
-  folder?: boolean;
   parent?: string;
   children?: IStashTab[];
 }
@@ -29,5 +27,8 @@ export interface ICompactTab {
 }
 
 export interface IMetaData {
-  colour: string;
+  colour?: string;
+  public?: boolean;
+  folder?: boolean;
+  items?: number;
 }

--- a/ExilenceNextApp/src/interfaces/stash.interface.ts
+++ b/ExilenceNextApp/src/interfaces/stash.interface.ts
@@ -1,35 +1,33 @@
 import { IItem } from './item.interface';
 
 export interface IStash {
-  numTabs: number;
-  tabs: IStashTab[];
-  items: IItem[];
-  mapLayout: any;
-  [x: string]: any;
+  stashes: IStashTab[];
+}
+
+export interface IStashTabResponse {
+  stash: IStashTab;
 }
 
 export interface IStashTab {
-  n: string;
-  i: number;
   id: string;
+  index: number;
+  name: string;
   type: string;
-  hidden: boolean;
-  selected: boolean;
-  colour: IColour;
-  srcL: string;
-  srcC: string;
-  srcR: string;
+  metadata: IMetaData;
+  items?: IItem[];
+  public?: boolean;
+  folder?: boolean;
+  parent?: string;
+  children?: IStashTab[];
 }
 
 export interface ICompactTab {
-  n: string;
-  i: number;
   id: string;
-  colour: IColour;
+  name: string;
+  index: number;
+  color: string;
 }
 
-export interface IColour {
-  r: number;
-  g: number;
-  b: number;
+export interface IMetaData {
+  colour: string;
 }

--- a/ExilenceNextApp/src/routes/net-worth/NetWorth.tsx
+++ b/ExilenceNextApp/src/routes/net-worth/NetWorth.tsx
@@ -94,6 +94,10 @@ const NetWorth = () => {
     uiStateStore!.setBulkSellView(false);
   }, []);
 
+  const chartData = activeGroup
+    ? activeGroup.sparklineChartData
+    : activeProfile?.sparklineChartData;
+
   return (
     <FeatureWrapper>
       <Grid container spacing={netWorthGridSpacing}>
@@ -111,15 +115,15 @@ const NetWorth = () => {
               currency
               tooltip="Change in value between the two latest snapshots"
               sparklineChart={
-                <SparklineChart
-                  internalName="networth"
-                  color={primaryLighter}
-                  height={20}
-                  width={90}
-                  data={
-                    activeGroup ? activeGroup.sparklineChartData : activeProfile?.sparklineChartData
-                  }
-                />
+                chartData && (
+                  <SparklineChart
+                    internalName="networth"
+                    color={primaryLighter}
+                    height={20}
+                    width={90}
+                    data={chartData}
+                  />
+                )
               }
               currencySwitch
             />

--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -10,7 +10,7 @@ import { ICharacter } from '../interfaces/character.interface';
 import { IGithubRelease } from '../interfaces/github/github-release.interface';
 import { ILeague } from '../interfaces/league.interface';
 import { IPoeProfile } from '../interfaces/poe-profile.interface';
-import { IStash, IStashTab } from '../interfaces/stash.interface';
+import { IStash, IStashTab, IStashTabResponse } from '../interfaces/stash.interface';
 import { mapItemsToPricedItems } from '../utils/item.utils';
 import AppConfig from './../config/app.config';
 import { IStashTabSnapshot } from './../interfaces/stash-tab-snapshot.interface';
@@ -44,43 +44,28 @@ function loginWithOAuth(code: string): Observable<AxiosResponse<any>> {
 /* #endregion */
 
 /* #region pathofexile.com */
-function getStashTab(
-  account: string,
-  league: string,
-  index: number,
-  realm?: string
-): Observable<AxiosResponse<IStash>> {
-  const parameters = `?league=${league}&accountName=${account}&tabIndex=${index}&tabs=1${getRealmParam(
-    realm
-  )}`;
-  return rateLimiter.limit(
-    axios.get<IStash>(poeUrl + '/character-window/get-stash-items' + parameters)
-  );
+function getStashTab(league: string, id: string): Observable<AxiosResponse<IStashTabResponse>> {
+  return rateLimiter.limit(axios.get<IStashTabResponse>(`${apiUrl}/stash/${league}/${id}`));
 }
 
-function getStashTabs(
-  account: string,
-  league: string,
-  realm?: string
-): Observable<AxiosResponse<IStash>> {
-  const parameters = `?league=${league}&accountName=${account}&tabs=1${getRealmParam(realm)}`;
-  return rateLimiter.limit(
-    axios.get<IStash>(poeUrl + '/character-window/get-stash-items' + parameters)
-  );
+function getStashTabs(league: string): Observable<AxiosResponse<IStash>> {
+  return rateLimiter.limit(axios.get<IStash>(`${apiUrl}/stash/${league}`));
 }
 
-function getItemsForTabs(tabs: IStashTab[], account: string, league: string, realm?: string) {
+function getItemsForTabs(tabs: IStashTab[], league: string) {
   if (tabs.length === 0) {
     return throwError(new Error('no_stash_tabs_selected_for_profile'));
   }
 
   return forkJoin(
     tabs.map((tab: IStashTab) => {
-      return getStashTab(account, league, tab.i, realm).pipe(
-        map((stash: AxiosResponse<IStash>) => {
+      return getStashTab(league, tab.id).pipe(
+        map((stashTab: AxiosResponse<IStashTabResponse>) => {
           rootStore.uiStateStore.incrementStatusMessageCount();
           const items = {
-            pricedItems: mapItemsToPricedItems(stash.data.items, tab),
+            pricedItems: stashTab.data.stash.items
+              ? mapItemsToPricedItems(stashTab.data.stash.items, tab)
+              : [],
           };
           return { ...{ stashTabId: tab.id }, ...items } as IStashTabSnapshot;
         })

--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -5,7 +5,6 @@ import RateLimiter from 'rxjs-ratelimiter';
 import { map } from 'rxjs/operators';
 
 import { rootStore } from '..';
-import { ICharacterWithItems } from '../interfaces/character-with-items.interface';
 import { ICharacter } from '../interfaces/character.interface';
 import { IGithubRelease } from '../interfaces/github/github-release.interface';
 import { ILeague } from '../interfaces/league.interface';
@@ -16,7 +15,6 @@ import AppConfig from './../config/app.config';
 import { IStashTabSnapshot } from './../interfaces/stash-tab-snapshot.interface';
 
 const rateLimiter = new RateLimiter(5, 10000);
-const poeUrl = AppConfig.pathOfExileUrl;
 const apiUrl = AppConfig.pathOfExileApiUrl;
 
 export const externalService = {
@@ -26,7 +24,7 @@ export const externalService = {
   getItemsForTabs,
   getLeagues,
   getCharacters,
-  getCharacterItems,
+  getCharacter,
   getProfile,
   loginWithOAuth,
 };
@@ -85,25 +83,12 @@ function getLeagues(
   );
 }
 
-function getCharacters(realm?: string): Observable<AxiosResponse<ICharacter[]>> {
-  // todo: create util for this realm segment
-  const parameters = `?realm=${realm}`;
-
-  return rateLimiter.limit(
-    axios.get<ICharacter[]>(poeUrl + '/character-window/get-characters' + parameters)
-  );
+function getCharacters(): Observable<AxiosResponse<ICharacter[]>> {
+  return rateLimiter.limit(axios.get<ICharacter[]>(`${apiUrl}/character`));
 }
 
-function getCharacterItems(
-  account: string,
-  character: string,
-  realm?: string
-): Observable<AxiosResponse<ICharacterWithItems>> {
-  const parameters = `?accountName=${account}&character=${character}${getRealmParam(realm)}`;
-
-  return rateLimiter.limit(
-    axios.get<ICharacterWithItems>(poeUrl + '/character-window/get-items' + parameters)
-  );
+function getCharacter(character: string): Observable<AxiosResponse<ICharacter>> {
+  return rateLimiter.limit(axios.get<ICharacter>(`${apiUrl}/character/${character}`));
 }
 
 function getProfile(realm: string = 'pc'): Observable<AxiosResponse<IPoeProfile>> {

--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -50,6 +50,9 @@ function getStashTabWithChildren(stashTab: IStashTab, league: string, children?:
     const prefix = tab.parent && children ? `${tab.parent}/` : '';
     return getStashTab(league, `${prefix}${tab.id}`).pipe(
       mergeMap((stashTab: AxiosResponse<IStashTabResponse>) => {
+        if (!children) {
+          rootStore.uiStateStore.incrementStatusMessageCount();
+        }
         return of(stashTab.data.stash);
       })
     );

--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import axios from 'axios-observable';
 import { forkJoin, from, Observable, of, throwError } from 'rxjs';
 import RateLimiter from 'rxjs-ratelimiter';
-import { concatMap, map, mergeMap } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 import { rootStore } from '..';
 import { ICharacterListResponse, ICharacterResponse } from '../interfaces/character.interface';
 import { IGithubRelease } from '../interfaces/github/github-release.interface';

--- a/ExilenceNextApp/src/services/external.service.ts
+++ b/ExilenceNextApp/src/services/external.service.ts
@@ -1,19 +1,14 @@
 import { AxiosResponse } from 'axios';
 import axios from 'axios-observable';
-import { forkJoin, from, Observable, of, throwError } from 'rxjs';
-import { concatMap, map, mergeMap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { concatMap, mergeMap } from 'rxjs/operators';
 import { rootStore } from '..';
 import { ICharacterListResponse, ICharacterResponse } from '../interfaces/character.interface';
 import { IGithubRelease } from '../interfaces/github/github-release.interface';
-import { IItem } from '../interfaces/item.interface';
 import { ILeague } from '../interfaces/league.interface';
 import { IPoeProfile } from '../interfaces/poe-profile.interface';
-import { IPricedItem } from '../interfaces/priced-item.interface';
 import { IStash, IStashTab, IStashTabResponse } from '../interfaces/stash.interface';
-import { mapItemsToPricedItems } from '../utils/item.utils';
-import { rateLimit } from '../utils/rxjs.utils';
 import AppConfig from './../config/app.config';
-import { IStashTabSnapshot } from './../interfaces/stash-tab-snapshot.interface';
 
 const apiUrl = AppConfig.pathOfExileApiUrl;
 
@@ -21,7 +16,7 @@ export const externalService = {
   getLatestRelease,
   getStashTab,
   getStashTabs,
-  getItemsForTab,
+  getStashTabWithChildren,
   getLeagues,
   getCharacters,
   getCharacter,
@@ -50,42 +45,12 @@ function getStashTabs(league: string): Observable<AxiosResponse<IStash>> {
   return axios.get<IStash>(`${apiUrl}/stash/${league}`);
 }
 
-function getItemsForTab(stashTab: IStashTab, league: string) {
-  const mapTabItems = (tab: IStashTab, items?: IItem[]) => {
-    return items ? mapItemsToPricedItems(items, tab) : [];
-  };
-
+function getStashTabWithChildren(stashTab: IStashTab, league: string, children?: boolean) {
   const makeRequest = (tab: IStashTab) => {
-    return getStashTab(league, tab.id).pipe(
+    const prefix = tab.parent && children ? `${tab.parent}/` : '';
+    return getStashTab(league, `${prefix}${tab.id}`).pipe(
       mergeMap((stashTab: AxiosResponse<IStashTabResponse>) => {
-        rootStore.rateLimitStore.parseRateLimitHeaders(stashTab.headers['x-rate-limit-account']);
-        rootStore.uiStateStore.incrementStatusMessageCount();
-        const children = stashTab.data.stash.children;
-        let finalizedItems: IPricedItem[] = [];
-        if (children) {
-          return from(children).pipe(
-            rootStore.rateLimitStore.rateLimiter1,
-            rootStore.rateLimitStore.rateLimiter2,
-            concatMap((c: IStashTab) => {
-              const prefix = c.parent ? `${c.parent}/` : '';
-              return getStashTab(league, `${prefix}${c.id}`).pipe(
-                map((ctab: AxiosResponse<IStashTabResponse>) => {
-                  finalizedItems = finalizedItems.concat(mapTabItems(c, ctab.data.stash.items));
-                  return {
-                    ...{ stashTabId: tab.id },
-                    ...{ pricedItems: finalizedItems },
-                  } as IStashTabSnapshot;
-                })
-              );
-            })
-          );
-        } else {
-          const items = mapTabItems(tab, stashTab.data.stash.items);
-          return of({
-            ...{ stashTabId: tab.id },
-            ...{ pricedItems: items },
-          } as IStashTabSnapshot);
-        }
+        return of(stashTab.data.stash);
       })
     );
   };

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -222,7 +222,7 @@ export class AccountStore {
           ).pipe(
             concatMap((requests) => {
               const leagues: ILeague[] = requests[0].data;
-              const characters: ICharacter[] = requests[1].data;
+              const characters: ICharacter[] = requests[1].data.characters;
               const unsupportedLeagues = ['Path of Exile: Royale'];
 
               if (leagues.length === 0) {

--- a/ExilenceNextApp/src/store/accountStore.ts
+++ b/ExilenceNextApp/src/store/accountStore.ts
@@ -1,6 +1,6 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import axios from 'axios-observable';
-import { action, autorun, computed, makeObservable, observable, reaction, runInAction } from 'mobx';
+import { action, autorun, computed, makeObservable, observable, runInAction } from 'mobx';
 import { persist } from 'mobx-persist';
 import { fromStream } from 'mobx-utils';
 import { forkJoin, of, Subject, throwError, timer } from 'rxjs';
@@ -217,7 +217,7 @@ export class AccountStore {
 
           return forkJoin(
             externalService.getLeagues('main', 1, res.realm),
-            externalService.getCharacters(res.realm),
+            externalService.getCharacters(),
             !skipAuth ? this.getSelectedAccount.authorize() : of({})
           ).pipe(
             concatMap((requests) => {

--- a/ExilenceNextApp/src/store/domains/account-league.ts
+++ b/ExilenceNextApp/src/store/domains/account-league.ts
@@ -37,28 +37,22 @@ export class AccountLeague {
 
   @action
   getStashTabs() {
-    return externalService
-      .getStashTabs(
-        rootStore.accountStore.getSelectedAccount.name!,
-        this.leagueId,
-        rootStore.uiStateStore.selectedPlatform.id
-      )
-      .pipe(
-        map((response: AxiosResponse<IStash>) => {
-          runInAction(() => {
-            if (response.data.tabs.length > 0) {
-              this.stashtabs = response.data.tabs.filter(
-                (s: IStashTab) => !AccountLeague.excludedStashTypes.includes(s.type)
-              );
-            }
-            this.getStashTabsSuccess();
-          });
-        }),
-        catchError((e: AxiosError) => {
-          of(this.getStashTabsFail(e));
-          throw e;
-        })
-      );
+    return externalService.getStashTabs(this.leagueId).pipe(
+      map((response: AxiosResponse<IStash>) => {
+        runInAction(() => {
+          if (response.data.stashes.length > 0) {
+            this.stashtabs = response.data.stashes.filter(
+              (s: IStashTab) => !AccountLeague.excludedStashTypes.includes(s.type)
+            );
+          }
+          this.getStashTabsSuccess();
+        });
+      }),
+      catchError((e: AxiosError) => {
+        of(this.getStashTabsFail(e));
+        throw e;
+      })
+    );
   }
 
   @action getStashTabsSuccess() {

--- a/ExilenceNextApp/src/store/domains/account-league.ts
+++ b/ExilenceNextApp/src/store/domains/account-league.ts
@@ -1,5 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios';
-import { action, makeObservable, observable, runInAction } from 'mobx';
+import { action, computed, makeObservable, observable, runInAction, toJS } from 'mobx';
 import { persist } from 'mobx-persist';
 import { of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -21,6 +21,13 @@ export class AccountLeague {
   constructor(id: string) {
     makeObservable(this);
     this.leagueId = id;
+  }
+
+  @computed get stashtabList() {
+    const flattenedTabs = this.stashtabs.flatMap((st) => {
+      return st.children ?? st;
+    });
+    return flattenedTabs;
   }
 
   @action

--- a/ExilenceNextApp/src/store/domains/account-league.ts
+++ b/ExilenceNextApp/src/store/domains/account-league.ts
@@ -16,8 +16,6 @@ export class AccountLeague {
   @persist('list', Character) @observable characters: Character[] = [];
   @persist('list') @observable stashtabs: IStashTab[] = [];
 
-  private static readonly excludedStashTypes: string[] = ['UniqueStash', 'MapStash'];
-
   constructor(id: string) {
     makeObservable(this);
     this.leagueId = id;
@@ -48,9 +46,7 @@ export class AccountLeague {
       map((response: AxiosResponse<IStash>) => {
         runInAction(() => {
           if (response.data.stashes.length > 0) {
-            this.stashtabs = response.data.stashes.filter(
-              (s: IStashTab) => !AccountLeague.excludedStashTypes.includes(s.type)
-            );
+            this.stashtabs = response.data.stashes;
           }
           this.getStashTabsSuccess();
         });

--- a/ExilenceNextApp/src/store/domains/account.ts
+++ b/ExilenceNextApp/src/store/domains/account.ts
@@ -5,13 +5,11 @@ import { fromStream } from 'mobx-utils';
 import { of, Subject, throwError, timer } from 'rxjs';
 import { catchError, map, mergeMap, retryWhen, switchMap, takeUntil } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
-
 import { IAccount } from '../../interfaces/account.interface';
 import { IApiAccount } from '../../interfaces/api/api-account.interface';
 import { IApiProfile } from '../../interfaces/api/api-profile.interface';
 import { ICharacter } from '../../interfaces/character.interface';
 import { authService } from '../../services/auth.service';
-import { rgbToHex } from '../../utils/colour.utils';
 import { mapProfileToApiProfile } from '../../utils/profile.utils';
 import { genericRetryStrategy } from '../../utils/rxjs.utils';
 import { rootStore, visitor } from './../../index';
@@ -44,7 +42,7 @@ export class Account implements IAccount {
       const accountLeague = this.accountLeagues.find((l) => l.leagueId === league?.id);
       return accountLeague?.stashtabs
         .filter((s) => this.activeProfile?.activeStashTabIds.includes(s.id))
-        .map((s) => rgbToHex(s.colour.r, s.colour.g, s.colour.b));
+        .map((s) => s.metadata.colour);
     } else {
       return undefined;
     }

--- a/ExilenceNextApp/src/store/domains/character.ts
+++ b/ExilenceNextApp/src/store/domains/character.ts
@@ -7,15 +7,18 @@ import { IItem } from '../../interfaces/item.interface';
 
 export class Character implements ICharacter {
   @persist uuid: string = uuidv4();
+  @persist id: string = '';
   @persist name: string = '';
-  @persist league: string = '';
-  @persist classId: number = -1;
-  @persist ascendancyClass: number = -1;
   @persist class: string = '';
   @persist level: number = -1;
-
+  @persist experience: number = -1;
+  @persist league?: string;
+  @persist expired?: boolean;
+  @persist current?: boolean;
+  @persist deleted?: boolean;
   @persist('list') @observable inventory: IItem[] = [];
   @persist('list') @observable equipment: IItem[] = [];
+  @persist('list') @observable jewels: IItem[] = [];
 
   constructor(obj?: ICharacter) {
     makeObservable(this);

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { action, computed, makeObservable, observable, runInAction, toJS } from 'mobx';
+import { action, computed, makeObservable, observable, runInAction } from 'mobx';
 import { persist } from 'mobx-persist';
 import { fromStream } from 'mobx-utils';
 import moment from 'moment';
@@ -222,7 +222,7 @@ export class Profile {
     }, Object.create(null));
 
     this.activeStashTabIds.map((id) => {
-      const stashTabName = accountLeague.stashtabs.find((s) => s.id === id)?.n;
+      const stashTabName = accountLeague.stashtabs.find((s) => s.id === id)?.name;
       const serie: IConnectionChartSeries = {
         seriesName: stashTabName ?? '',
         series: formatStashTabSnapshotsForChart(
@@ -464,12 +464,7 @@ export class Profile {
 
     fromStream(
       forkJoin(
-        externalService.getItemsForTabs(
-          selectedStashTabs,
-          rootStore.accountStore.getSelectedAccount.name!,
-          league.id,
-          rootStore.uiStateStore.selectedPlatform.id
-        ),
+        externalService.getItemsForTabs(selectedStashTabs, league.id),
         this.activeCharacterName &&
           this.activeCharacterName !== '' &&
           this.activeCharacterName !== 'None'

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -482,6 +482,10 @@ export class Profile {
           const subTabs = response[0]
             .filter((sst) => sst.children)
             .flatMap((sst) => sst.children ?? sst);
+          // if no subtabs exist, simply return the original request
+          if (subTabs.length === 0) {
+            return of(response);
+          }
           const getItemsForSubTabs = forkJoin(
             subTabs.map((tab) => {
               return externalService.getStashTabWithChildren(tab, league.id, true);

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -486,6 +486,7 @@ export class Profile {
           if (subTabs.length === 0) {
             return of(response);
           }
+          rootStore.uiStateStore.setStatusMessage('fetching_subtabs');
           const getItemsForSubTabs = forkJoin(
             subTabs.map((tab) => {
               return externalService.getStashTabWithChildren(tab, league.id, true);

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -488,9 +488,10 @@ export class Profile {
           : of(null)
       ).pipe(
         switchMap((response) => {
-          const subTabs = response[0]
+          let subTabs = response[0]
             .filter((sst) => sst.children)
             .flatMap((sst) => sst.children ?? sst);
+          subTabs = firstStashTab ? subTabs.concat([firstStashTab]) : subTabs;
           // if no subtabs exist, simply return the original request
           if (subTabs.length === 0) {
             return of(response);

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -465,12 +465,15 @@ export class Profile {
     }
 
     const tabsToFetch = firstStashTab ? selectedStashTabs.slice(1) : selectedStashTabs;
-    const getMainTabsWithChildren = forkJoin(
-      // slice away first because we already fetched it when checking headers
-      tabsToFetch.map((tab: IStashTab) => {
-        return externalService.getStashTabWithChildren(tab, league.id);
-      })
-    );
+    const getMainTabsWithChildren =
+      tabsToFetch.length > 0
+        ? forkJoin(
+            // slice away first because we already fetched it when checking headers
+            tabsToFetch.map((tab: IStashTab) => {
+              return externalService.getStashTabWithChildren(tab, league.id);
+            })
+          )
+        : of([]);
 
     rootStore.uiStateStore.setStatusMessage(
       'fetching_stash_tab',
@@ -491,7 +494,10 @@ export class Profile {
           let subTabs = response[0]
             .filter((sst) => sst.children)
             .flatMap((sst) => sst.children ?? sst);
-          subTabs = firstStashTab ? subTabs.concat([firstStashTab]) : subTabs;
+          subTabs =
+            firstStashTab && firstStashTab.children
+              ? subTabs.concat(firstStashTab.children)
+              : subTabs;
           // if no subtabs exist, simply return the original request
           if (subTabs.length === 0) {
             return of(response);

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -468,28 +468,23 @@ export class Profile {
         this.activeCharacterName &&
           this.activeCharacterName !== '' &&
           this.activeCharacterName !== 'None'
-          ? externalService.getCharacterItems(
-              rootStore.accountStore.getSelectedAccount.name!,
-              this.activeCharacterName,
-              rootStore.uiStateStore.selectedPlatform.id
-            )
+          ? externalService.getCharacter(this.activeCharacterName)
           : of(null)
       ).pipe(
         map((result) => {
           const stashTabsWithItems = result[0];
           const characterWithItems = result[1];
           if (characterWithItems?.data) {
-            const characterItems = mapItemsToPricedItems(characterWithItems?.data?.items);
             let includedCharacterItems: IPricedItem[] = [];
             if (this.includeInventory) {
-              includedCharacterItems = includedCharacterItems.concat(
-                characterItems.filter((ci) => ci.inventoryId === 'MainInventory')
-              );
+              const inventory = characterWithItems?.data?.inventory;
+              const mappedInventory = inventory ? mapItemsToPricedItems(inventory) : [];
+              includedCharacterItems = includedCharacterItems.concat(mappedInventory);
             }
             if (this.includeEquipment) {
-              includedCharacterItems = includedCharacterItems.concat(
-                characterItems.filter((ci) => ci.inventoryId !== 'MainInventory')
-              );
+              const equipment = characterWithItems?.data?.equipment;
+              const mappedEquipment = equipment ? mapItemsToPricedItems(equipment) : [];
+              includedCharacterItems = includedCharacterItems.concat(mappedEquipment);
             }
             const characterTab: IStashTabSnapshot = {
               stashTabId: 'Character',

--- a/ExilenceNextApp/src/store/domains/profile.ts
+++ b/ExilenceNextApp/src/store/domains/profile.ts
@@ -413,7 +413,7 @@ export class Profile {
     rootStore.uiStateStore.setStatusMessage('refreshing_stash_tabs');
 
     fromStream(
-      accountLeague.getStashTabs(rootStore.rateLimitStore.shouldUpdateLimits).pipe(
+      accountLeague.getStashTabs(true).pipe(
         mergeMap((response) => of(this.refreshStashTabsSuccess(league.id, response))),
         catchError((e: AxiosError) => of(this.refreshStashTabsFail(e, league.id)))
       )
@@ -467,7 +467,7 @@ export class Profile {
     const tabsToFetch = firstStashTab ? selectedStashTabs.slice(1) : selectedStashTabs;
     const getMainTabsWithChildren = forkJoin(
       // slice away first because we already fetched it when checking headers
-      tabsToFetch.slice(1).map((tab: IStashTab) => {
+      tabsToFetch.map((tab: IStashTab) => {
         return externalService.getStashTabWithChildren(tab, league.id);
       })
     );

--- a/ExilenceNextApp/src/store/domains/stash-tab.ts
+++ b/ExilenceNextApp/src/store/domains/stash-tab.ts
@@ -2,20 +2,18 @@ import { makeObservable } from 'mobx';
 import { persist } from 'mobx-persist';
 import { v4 as uuidv4 } from 'uuid';
 
-import { IColour, IStashTab } from '../../interfaces/stash.interface';
+import { IMetaData, IStashTab } from '../../interfaces/stash.interface';
 
 export class StashTab implements IStashTab {
   @persist uuid: string = uuidv4();
-  @persist n: string = '';
-  @persist i: number = 0;
   @persist id: string = '';
+  @persist name: string = '';
+  @persist index: number = 0;
   @persist type: string = '';
-  @persist hidden: boolean = false;
-  @persist selected: boolean = false;
-  @persist('object') colour: IColour = { r: 0, g: 0, b: 0 };
-  @persist srcL: string = '';
-  @persist srcC: string = '';
-  @persist srcR: string = '';
+  @persist parent?: string;
+  @persist folder?: boolean;
+  @persist public?: boolean;
+  @persist('object') metadata: IMetaData = { colour: '' };
 
   constructor(obj?: IStashTab) {
     makeObservable(this);

--- a/ExilenceNextApp/src/store/migrationStore.ts
+++ b/ExilenceNextApp/src/store/migrationStore.ts
@@ -8,7 +8,7 @@ import { RootStore } from './rootStore';
 import { fromStream } from 'mobx-utils';
 
 export class MigrationStore {
-  @observable @persist current: number = 1;
+  @observable @persist current: number = 2;
   @observable latest: number = 3;
 
   constructor(private rootStore: RootStore) {
@@ -65,14 +65,11 @@ export class MigrationStore {
           let observable: Observable<void | {}> = of({});
           switch (this.current) {
             case 1:
-              // version 1
+              // from version 1
               observable = this.clearStorage();
               break;
             case 2:
-              // version 2
-              break;
-            case 3:
-              // version 3
+              // from version 2
               observable = this.clearStorage();
               break;
             default:

--- a/ExilenceNextApp/src/store/migrationStore.ts
+++ b/ExilenceNextApp/src/store/migrationStore.ts
@@ -9,7 +9,7 @@ import { fromStream } from 'mobx-utils';
 
 export class MigrationStore {
   @observable @persist current: number = 1;
-  @observable latest: number = 2;
+  @observable latest: number = 3;
 
   constructor(private rootStore: RootStore) {
     makeObservable(this);
@@ -66,6 +66,13 @@ export class MigrationStore {
           switch (this.current) {
             case 1:
               // version 1
+              observable = this.clearStorage();
+              break;
+            case 2:
+              // version 2
+              break;
+            case 3:
+              // version 3
               observable = this.clearStorage();
               break;
             default:

--- a/ExilenceNextApp/src/store/rateLimitStore.ts
+++ b/ExilenceNextApp/src/store/rateLimitStore.ts
@@ -1,0 +1,57 @@
+import { action, makeObservable } from 'mobx';
+import { rateLimit } from '../utils/rxjs.utils';
+import { RootStore } from './rootStore';
+
+interface IRateLimitBoundaries {
+  requests: number;
+  interval: number;
+}
+
+// prio: fix snapshotting since we return different array
+
+// todo: parse remaining requests until limit
+// todo: parse remaining time on current limit
+// todo: test timer for limits
+
+export class RateLimitStore {
+  rateLimiter1 = rateLimit(13, 10 * 1000);
+  rateLimiter2 = rateLimit(27, 300 * 1000);
+
+  constructor(private rootStore: RootStore) {
+    makeObservable(this);
+  }
+
+  @action
+  setRateLimiter1(limit: IRateLimitBoundaries) {
+    // todo: only update when needed
+  }
+
+  @action
+  setRateLimiter2(limit: IRateLimitBoundaries) {
+    // todo: update headers when needed
+  }
+
+  @action
+  parseRateLimitHeaders(headers: string) {
+    if (headers) {
+      const _inner = headers.split(',').shift()?.split(':');
+      if (_inner && _inner.length > 0) {
+        const _requests = _inner[0];
+        const _interval = _inner[1];
+        this.setRateLimiter1({
+          requests: +_requests - +_requests * 0.2,
+          interval: +_interval * 1000,
+        });
+      }
+      const _outer = headers.split(',').pop()?.split(':');
+      if (_outer && _outer.length > 0) {
+        const _requests = _outer[0];
+        const _interval = _outer[1];
+        this.setRateLimiter2({
+          requests: +_requests - +_requests * 0.2,
+          interval: +_interval * 1000,
+        });
+      }
+    }
+  }
+}

--- a/ExilenceNextApp/src/store/rateLimitStore.ts
+++ b/ExilenceNextApp/src/store/rateLimitStore.ts
@@ -1,4 +1,5 @@
 import { action, makeObservable } from 'mobx';
+import { queueScheduler } from 'rxjs';
 import { rateLimit } from '../utils/rxjs.utils';
 import { RootStore } from './rootStore';
 
@@ -14,8 +15,8 @@ interface IRateLimitBoundaries {
 // todo: test timer for limits
 
 export class RateLimitStore {
-  rateLimiter1 = rateLimit(13, 10 * 1000);
-  rateLimiter2 = rateLimit(27, 300 * 1000);
+  rateLimiter1 = rateLimit(13, 10 * 1000, queueScheduler);
+  rateLimiter2 = rateLimit(27, 300 * 1000, queueScheduler);
 
   constructor(private rootStore: RootStore) {
     makeObservable(this);

--- a/ExilenceNextApp/src/store/rateLimitStore.ts
+++ b/ExilenceNextApp/src/store/rateLimitStore.ts
@@ -1,4 +1,4 @@
-import { action, makeObservable } from 'mobx';
+import { action, makeObservable, observable, runInAction } from 'mobx';
 import { queueScheduler } from 'rxjs';
 import { rateLimit } from '../utils/rxjs.utils';
 import { RootStore } from './rootStore';
@@ -8,15 +8,36 @@ interface IRateLimitBoundaries {
   interval: number;
 }
 
-// prio: fix snapshotting since we return different array
+// prio: optimize, right now we waste 1 request to check limits every snapshot
 
 // todo: parse remaining requests until limit
 // todo: parse remaining time on current limit
-// todo: test timer for limits
+
+const rateLimiter1Defaults: IRateLimitBoundaries = {
+  requests: 14,
+  interval: 10 * 1000,
+};
+
+const rateLimiter2Defaults: IRateLimitBoundaries = {
+  requests: 29,
+  interval: 300 * 1000,
+};
 
 export class RateLimitStore {
-  rateLimiter1 = rateLimit(13, 10 * 1000, queueScheduler);
-  rateLimiter2 = rateLimit(27, 300 * 1000, queueScheduler);
+  @observable rateLimiter1limits = rateLimiter1Defaults;
+  @observable rateLimiter2limits = rateLimiter2Defaults;
+  // set to true just to test
+  @observable shouldUpdateLimits = false;
+  @observable rateLimiter1 = rateLimit(
+    this.rateLimiter1limits.requests,
+    this.rateLimiter1limits.interval,
+    queueScheduler
+  );
+  @observable rateLimiter2 = rateLimit(
+    this.rateLimiter2limits.requests,
+    this.rateLimiter2limits.interval,
+    queueScheduler
+  );
 
   constructor(private rootStore: RootStore) {
     makeObservable(this);
@@ -24,12 +45,12 @@ export class RateLimitStore {
 
   @action
   setRateLimiter1(limit: IRateLimitBoundaries) {
-    // todo: only update when needed
+    this.rateLimiter1 = rateLimit(limit.requests, limit.interval, queueScheduler);
   }
 
   @action
   setRateLimiter2(limit: IRateLimitBoundaries) {
-    // todo: only update when needed
+    this.rateLimiter2 = rateLimit(limit.requests, limit.interval, queueScheduler);
   }
 
   @action
@@ -37,22 +58,41 @@ export class RateLimitStore {
     if (headers) {
       const _inner = headers.split(',').shift()?.split(':');
       if (_inner && _inner.length > 0) {
-        const _requests = _inner[0];
-        const _interval = _inner[1];
-        this.setRateLimiter1({
-          requests: +_requests - +_requests * 0.2,
-          interval: +_interval * 1000,
-        });
+        const _requests = +_inner[0] - 1;
+        const _interval = +_inner[1] * 1000;
+        if (
+          _requests !== this.rateLimiter1limits.requests ||
+          _interval !== this.rateLimiter1limits.interval
+        ) {
+          runInAction(() => {
+            this.shouldUpdateLimits = true;
+            this.rateLimiter1limits = { requests: _requests, interval: _interval };
+          });
+        }
       }
       const _outer = headers.split(',').pop()?.split(':');
       if (_outer && _outer.length > 0) {
-        const _requests = _outer[0];
-        const _interval = _outer[1];
-        this.setRateLimiter2({
-          requests: +_requests - +_requests * 0.2,
-          interval: +_interval * 1000,
-        });
+        const _requests = +_outer[0] - 1;
+        const _interval = +_outer[1] * 1000;
+        if (
+          _requests !== this.rateLimiter2limits.requests ||
+          _interval !== this.rateLimiter2limits.interval
+        ) {
+          runInAction(() => {
+            this.shouldUpdateLimits = true;
+            this.rateLimiter2limits = { requests: _requests, interval: _interval };
+          });
+        }
       }
     }
+  }
+
+  @action
+  updateLimits() {
+    this.setRateLimiter1(this.rateLimiter1limits);
+    this.setRateLimiter2(this.rateLimiter2limits);
+    runInAction(() => {
+      this.shouldUpdateLimits = false;
+    });
   }
 }

--- a/ExilenceNextApp/src/store/rateLimitStore.ts
+++ b/ExilenceNextApp/src/store/rateLimitStore.ts
@@ -28,7 +28,7 @@ export class RateLimitStore {
 
   @action
   setRateLimiter2(limit: IRateLimitBoundaries) {
-    // todo: update headers when needed
+    // todo: only update when needed
   }
 
   @action

--- a/ExilenceNextApp/src/store/rateLimitStore.ts
+++ b/ExilenceNextApp/src/store/rateLimitStore.ts
@@ -8,9 +8,6 @@ interface IRateLimitBoundaries {
   interval: number;
 }
 
-// prio: optimize, right now we waste 1 request to check limits every snapshot
-
-// todo: parse remaining requests until limit
 // todo: parse remaining time on current limit
 
 const rateLimiter1Defaults: IRateLimitBoundaries = {
@@ -26,7 +23,6 @@ const rateLimiter2Defaults: IRateLimitBoundaries = {
 export class RateLimitStore {
   @observable rateLimiter1limits = rateLimiter1Defaults;
   @observable rateLimiter2limits = rateLimiter2Defaults;
-  // set to true just to test
   @observable shouldUpdateLimits = false;
   @observable rateLimiter1 = rateLimit(
     this.rateLimiter1limits.requests,

--- a/ExilenceNextApp/src/store/rootStore.ts
+++ b/ExilenceNextApp/src/store/rootStore.ts
@@ -7,6 +7,7 @@ import { MigrationStore } from './migrationStore';
 import { NotificationStore } from './notificationStore';
 import { OverlayStore } from './overlayStore';
 import { PriceStore } from './priceStore';
+import { RateLimitStore } from './rateLimitStore';
 import { RouteStore } from './routeStore';
 import { SettingStore } from './settingStore';
 import { SignalrStore } from './signalrStore';
@@ -28,6 +29,7 @@ export class RootStore {
   overlayStore: OverlayStore;
   logStore: LogStore;
   customPriceStore: CustomPriceStore;
+  rateLimitStore: RateLimitStore;
 
   constructor() {
     this.uiStateStore = new UiStateStore(this);
@@ -44,5 +46,6 @@ export class RootStore {
     this.overlayStore = new OverlayStore(this);
     this.logStore = new LogStore(this);
     this.customPriceStore = new CustomPriceStore(this);
+    this.rateLimitStore = new RateLimitStore(this);
   }
 }

--- a/ExilenceNextApp/src/store/settingStore.ts
+++ b/ExilenceNextApp/src/store/settingStore.ts
@@ -19,7 +19,7 @@ export class SettingStore {
   @persist @observable priceThreshold: number = 0;
   @persist @observable totalPriceThreshold: number = 0;
   @persist @observable showPriceInExalt = false;
-  @persist @observable autoSnapshotInterval: number = 60 * 2 * 1000; // default to 2 minutes
+  @persist @observable autoSnapshotInterval: number = 60 * 5 * 1000; // default to 5 minutes
   @persist @observable uiScale: number = electronService.webFrame.getZoomFactor() * 100;
   @persist @observable logPath: string =
     'C:/Program Files (x86)/Grinding Gear Games/Path of Exile/logs/Client.txt';

--- a/ExilenceNextApp/src/store/uiStateStore.ts
+++ b/ExilenceNextApp/src/store/uiStateStore.ts
@@ -4,9 +4,9 @@ import { persist } from 'mobx-persist';
 import { map } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 import { IApiAnnouncement } from '../interfaces/api/api-announcement.interface';
+import { IBulkSellColumnPreset } from '../interfaces/bulk-sell-column-preset.interface';
 import { IPricedItem } from '../interfaces/priced-item.interface';
 import { ISelectOption } from '../interfaces/select-option.interface';
-
 import { IStashTab } from '../interfaces/stash.interface';
 import { IStatusMessage } from '../interfaces/status-message.interface';
 import { TimespanType } from '../types/timespan.type';
@@ -15,8 +15,6 @@ import { ICookie } from './../interfaces/cookie.interface';
 import { authService } from './../services/auth.service';
 import { Notification } from './domains/notification';
 import { RootStore } from './rootStore';
-import { IBulkSellColumnPreset } from '../interfaces/bulk-sell-column-preset.interface';
-import RateLimiter from 'rxjs-ratelimiter';
 
 export type GroupDialogType = 'create' | 'join' | undefined;
 
@@ -97,16 +95,8 @@ export class UiStateStore {
   @persist @observable bulkSellGeneratedMessage: string = '';
   @persist @observable bulkSellGeneratingImage: boolean = false;
 
-  // default: 1 req per 10 sec = 30 req over 5 min
-  @observable rateLimiter = new RateLimiter(1, 10 * 1000);
-
   constructor(private rootStore: RootStore) {
     makeObservable(this);
-  }
-
-  @action.bound
-  setRateLimit(requests: number, interval: number) {
-    this.rateLimiter = new RateLimiter(1, (interval / requests) * 1000);
   }
 
   @action

--- a/ExilenceNextApp/src/store/uiStateStore.ts
+++ b/ExilenceNextApp/src/store/uiStateStore.ts
@@ -16,6 +16,7 @@ import { authService } from './../services/auth.service';
 import { Notification } from './domains/notification';
 import { RootStore } from './rootStore';
 import { IBulkSellColumnPreset } from '../interfaces/bulk-sell-column-preset.interface';
+import RateLimiter from 'rxjs-ratelimiter';
 
 export type GroupDialogType = 'create' | 'join' | undefined;
 
@@ -96,8 +97,16 @@ export class UiStateStore {
   @persist @observable bulkSellGeneratedMessage: string = '';
   @persist @observable bulkSellGeneratingImage: boolean = false;
 
+  // default: 1 req per 10 sec = 30 req over 5 min
+  @observable rateLimiter = new RateLimiter(1, 10 * 1000);
+
   constructor(private rootStore: RootStore) {
     makeObservable(this);
+  }
+
+  @action.bound
+  setRateLimit(requests: number, interval: number) {
+    this.rateLimiter = new RateLimiter(1, (interval / requests) * 1000);
   }
 
   @action

--- a/ExilenceNextApp/src/utils/item.utils.ts
+++ b/ExilenceNextApp/src/utils/item.utils.ts
@@ -45,10 +45,11 @@ export function formatSnapshotsForTable(stashTabSnapshots: IStashTabSnapshot[]) 
 }
 
 export function parseTabNames(tabs: ICompactTab[]) {
-  return tabs.map((t) => t.n).join(', ');
+  return tabs.map((t) => t.name).join(', ');
 }
 
 export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
+  console.log('items for tab before map', items);
   return items.map((item: IItem) => {
     const mapTier =
       item.properties !== null && item.properties !== undefined ? getMapTier(item.properties) : 0;
@@ -93,10 +94,10 @@ export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
       tab: tab
         ? [
             {
-              n: tab.n,
-              i: tab.i,
+              name: tab.name,
+              index: tab.index,
               id: tab.id,
-              colour: tab.colour,
+              color: tab.metadata.colour,
             } as ICompactTab,
           ]
         : [],

--- a/ExilenceNextApp/src/utils/item.utils.ts
+++ b/ExilenceNextApp/src/utils/item.utils.ts
@@ -49,7 +49,6 @@ export function parseTabNames(tabs: ICompactTab[]) {
 }
 
 export function mapItemsToPricedItems(items: IItem[], tab?: IStashTab) {
-  console.log('items for tab before map', items);
   return items.map((item: IItem) => {
     const mapTier =
       item.properties !== null && item.properties !== undefined ? getMapTier(item.properties) : 0;

--- a/ExilenceNextApp/src/utils/league.utils.ts
+++ b/ExilenceNextApp/src/utils/league.utils.ts
@@ -4,9 +4,11 @@ import { ILeague } from '../interfaces/league.interface';
 export function getCharacterLeagues(characters: ICharacter[]) {
   const distinctLeagues: ILeague[] = [];
   characters.map((c) => {
-    const foundLeague = distinctLeagues.find((l) => l.id === c.league);
-    if (!foundLeague) {
-      distinctLeagues.push({ id: c.league });
+    if (c.league) {
+      const foundLeague = distinctLeagues.find((l) => l.id === c.league);
+      if (!foundLeague) {
+        distinctLeagues.push({ id: c.league });
+      }
     }
   });
   return distinctLeagues;

--- a/ExilenceNextApp/src/utils/rxjs.utils.ts
+++ b/ExilenceNextApp/src/utils/rxjs.utils.ts
@@ -1,5 +1,12 @@
-import { Observable, throwError, timer } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import {
+  asyncScheduler,
+  BehaviorSubject,
+  Observable,
+  OperatorFunction,
+  throwError,
+  timer,
+} from 'rxjs';
+import { filter, map, mergeMap, take } from 'rxjs/operators';
 
 export const genericRetryStrategy = ({
   maxRetryAttempts = 3,
@@ -23,3 +30,26 @@ export const genericRetryStrategy = ({
     })
   );
 };
+
+export function rateLimit<T>(count: number, slidingWindowTime: number, scheduler = asyncScheduler) {
+  let tokens = count;
+  const tokenChanged = new BehaviorSubject(tokens);
+  const consumeToken = () => tokenChanged.next(--tokens);
+  const renewToken = () => tokenChanged.next(++tokens);
+  const availableTokens = tokenChanged.pipe(filter(() => tokens > 0));
+
+  return function (source: { pipe: (arg0: OperatorFunction<T, T>) => any }) {
+    return source.pipe(
+      mergeMap<T, Observable<T>>((value: T) =>
+        availableTokens.pipe(
+          take(1),
+          map(() => {
+            consumeToken();
+            timer(slidingWindowTime, scheduler).subscribe(renewToken);
+            return value;
+          })
+        )
+      )
+    );
+  };
+}

--- a/ExilenceNextApp/src/utils/snapshot.utils.ts
+++ b/ExilenceNextApp/src/utils/snapshot.utils.ts
@@ -7,7 +7,6 @@ import { IApiStashTabPricedItem } from '../interfaces/api/api-stashtab-pricedite
 import { IChartStashTabSnapshot } from '../interfaces/chart-stash-tab-snapshot.interface';
 import { IStashTab } from '../interfaces/stash.interface';
 import { Snapshot } from '../store/domains/snapshot';
-import { rgbToHex } from './colour.utils';
 import { getRarityIdentifier, mergeItemStacks } from './item.utils';
 
 export const mapSnapshotToApiSnapshot = (snapshot: Snapshot, stashTabs?: IStashTab[]) => {
@@ -24,12 +23,10 @@ export const mapSnapshotToApiSnapshot = (snapshot: Snapshot, stashTabs?: IStashT
             uuid: st.uuid,
             stashTabId: foundTab?.id,
             pricedItems: st.pricedItems,
-            index: foundTab?.i,
+            index: foundTab?.index,
             value: st.value,
-            color: foundTab
-              ? rgbToHex(foundTab.colour.r, foundTab.colour.g, foundTab.colour.b)
-              : undefined,
-            name: foundTab?.n,
+            color: foundTab ? foundTab.metadata.colour : undefined,
+            name: foundTab?.name,
           } as IApiStashTabSnapshot;
         })
       : snapshot.stashTabSnapshots,
@@ -150,7 +147,7 @@ export const filterItems = (snapshots: IApiSnapshot[]) => {
             (i.calculated > 0 && i.name.toLowerCase().includes(filterText)) ||
             (i.tab &&
               i.tab
-                .map((t) => t.n)
+                .map((t) => t.name)
                 .join(', ')
                 .toLowerCase()
                 .includes(filterText)) ||


### PR DESCRIPTION
We have been using the `/character-window` api since the newly developed api (https://api.pathofexile.com) previously did not include everything we needed. This is no logner the case, and we can now start using the new API.

- [x] Replaced old endpoints
- [x] Updated interfaces
- [x] Added support for unique tab
- [x] Added support for map tab
- [x] Tested thoroughly by comparing the old and new API
- [x] Test migrationstore to make sure we can safely migrate to this version
- [x] Reworked rate limitation
   - [x] Now parses the headers of requests
   - [x] At every snapshot and for every tab, we check the headers and reconfigure them
   
Fixes #658, #533, #707 (referencing old issues related to map/unique tab)