### PR TITLE
feat(table): added column for displaying cumulative value (rolling sum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Added support for pricing `Blighted`, `Elder` and `Shaper` maps
 - Added support for pricing `Awakened`, `Anomalous` and `Divergent` gems
 - Added the ability to cancel an ongoing snapshot
+- Added a new column `Cumulative` to the item table
 - Added display of map tier in the item table
 - Added a sparkline chart to the net worth card
 - Added beta labels to new features

--- a/ExilenceNextApp/src/components/bulk-sell-column-presets-panel/supportedPresets.ts
+++ b/ExilenceNextApp/src/components/bulk-sell-column-presets-panel/supportedPresets.ts
@@ -1,7 +1,7 @@
 const SUPPORTED_PRESETS = [
   {
     name: 'value.custom',
-    hiddenColumns: [],
+    hiddenColumns: ['quality', 'level', 'corrupted'],
   },
   {
     name: 'label.breachstones',

--- a/ExilenceNextApp/src/components/columns/Columns.tsx
+++ b/ExilenceNextApp/src/components/columns/Columns.tsx
@@ -142,12 +142,13 @@ export function itemTabs(options: { accessor: string; header: string }): Column<
 }
 
 export function itemValue(options: {
-  accessor: string;
+  accessor?: string;
   header: string;
   editable?: boolean;
   placeholder?: string;
+  cumulative?: boolean;
 }): Column<object> {
-  const { header, accessor, editable, placeholder } = options;
+  const { header, accessor, editable, placeholder, cumulative } = options;
 
   return {
     Header: header,
@@ -155,7 +156,18 @@ export function itemValue(options: {
     align: 'right',
     // eslint-disable-next-line react/display-name
     Cell: (data: any) => {
-      const value = data.row.values[accessor];
+      let value = 0;
+      if (cumulative) {
+        value = data.row.original.total;
+        for (let i = 0; i < data.sortedRows.length; i++) {
+          if (data.sortedRows[i].id === data.row.id) {
+            break;
+          }
+          value += data.sortedRows[i].original.total;
+        }
+      } else if (accessor) {
+        value = data.row.values[accessor];
+      }
       return (
         <ItemValueCell
           value={value}
@@ -303,7 +315,7 @@ const ItemValueCellComponent = ({
             color: itemColors.chaosOrb,
           }}
         >
-          {value ? tryParseNumber(value) : placeholder}
+          {value ? tryParseNumber(value) : placeholder}{' '}
         </span>
       ) : (
         <span className={classes.lastCell}>{placeholder}</span>

--- a/ExilenceNextApp/src/components/columns/Columns.tsx
+++ b/ExilenceNextApp/src/components/columns/Columns.tsx
@@ -315,7 +315,7 @@ const ItemValueCellComponent = ({
             color: itemColors.chaosOrb,
           }}
         >
-          {value ? tryParseNumber(value) : placeholder}{' '}
+          {value ? tryParseNumber(value) : placeholder}
         </span>
       ) : (
         <span className={classes.lastCell}>{placeholder}</span>

--- a/ExilenceNextApp/src/components/item-table/itemTableColumns.ts
+++ b/ExilenceNextApp/src/components/item-table/itemTableColumns.ts
@@ -60,6 +60,10 @@ const itemTableColumns: Column<object>[] = [
     accessor: 'total',
     header: 'Total value (c)',
   }),
+  itemValue({
+    header: 'Cumulative (c)',
+    cumulative: true,
+  }),
 ];
 
 export default itemTableColumns;

--- a/ExilenceNextApp/src/components/table-wrapper/TableWrapper.styles.ts
+++ b/ExilenceNextApp/src/components/table-wrapper/TableWrapper.styles.ts
@@ -55,6 +55,9 @@ export const useStyles = makeStyles((theme: Theme) =>
       },
       borderBottom: '1px solid rgba(81, 81, 81, 0.6)',
     },
+    disabledSortBy: {
+      paddingRight: theme.spacing(2),
+    },
     placeholderRow: {
       backgroundColor: theme.palette.background.paper,
       '&:hover': {

--- a/ExilenceNextApp/src/components/table-wrapper/TableWrapper.tsx
+++ b/ExilenceNextApp/src/components/table-wrapper/TableWrapper.tsx
@@ -83,7 +83,9 @@ const TableWrapper = ({
                 return (
                   <div
                     {...column.getHeaderProps(headerProps)}
-                    className={classes.tableHeadCell}
+                    className={clsx(classes.tableHeadCell, {
+                      [classes.disabledSortBy]: !column.accessor,
+                    })}
                     key={`column_${j}`}
                   >
                     {column.canSort ? (

--- a/ExilenceNextApp/src/interfaces/priced-item.interface.ts
+++ b/ExilenceNextApp/src/interfaces/priced-item.interface.ts
@@ -30,4 +30,5 @@ export interface IPricedItem {
   inventoryId: string;
   tab: ICompactTab[];
   detailsUrl?: string;
+  cumulative?: number;
 }

--- a/ExilenceNextApp/src/interfaces/priced-item.interface.ts
+++ b/ExilenceNextApp/src/interfaces/priced-item.interface.ts
@@ -30,5 +30,4 @@ export interface IPricedItem {
   inventoryId: string;
   tab: ICompactTab[];
   detailsUrl?: string;
-  cumulative?: number;
 }


### PR DESCRIPTION
Basically added a column for displaying a rolling sum. Useful if you want to see the total accumulated value of top X items in the table, so you know what you would get if you sold those X items.

Also changed the default preset for the custom preset.

Closes #523 