### PR TITLE
feat(windows): custom installation path for win

### DIFF
--- a/ExilenceNextApp/package.json
+++ b/ExilenceNextApp/package.json
@@ -136,6 +136,11 @@
     "win": {
       "icon": "build/icon.ico"
     },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "deleteAppDataOnUninstall": true
+    },
     "mac": {
       "icon": "build/icon512x512.png",
       "category": "public.app-category.utilities"


### PR DESCRIPTION
Currently users can't decide where they want to install Exilence Next.
The data is also not being removed during uninstallation process causing confusion to users thinking that uninstalling may reset the data.

![https://i.gyazo.com/15563a8b3b8d82e3f8a8dd168fa1457c.gif](https://i.gyazo.com/15563a8b3b8d82e3f8a8dd168fa1457c.gif)