### PR TITLE
fix wrong path to translation files when building

### DIFF
--- a/ExilenceNextApp/src/config/i18n.ts
+++ b/ExilenceNextApp/src/config/i18n.ts
@@ -10,7 +10,7 @@ const url = require('url');
 function getTranslationPath(lng: string, ns: string) {
   const langPath = `/i18n/${lng}/${ns}.json`;
   const fullPath = url.format({
-    pathname: path.join(electronService.appPath, `../public/${langPath}`),
+    pathname: path.join(electronService.appPath, `../${langPath}`),
     protocol: 'file:',
     slashes: true,
   });


### PR DESCRIPTION
electronService.appPath points to the /build path.
The /build path doesn't have a "public" directory.

This build needs to be tested on Windows, which I don't have available at the moment.