### PR TITLE
Fix RemoveSnapshots datetime format

### DIFF
--- a/ExilenceNextApp/src/components/remove-snapshots-dialog/RemoveSnapshotsDialog.tsx
+++ b/ExilenceNextApp/src/components/remove-snapshots-dialog/RemoveSnapshotsDialog.tsx
@@ -96,7 +96,7 @@ const RemoveSnapshotsDialog = ({
                   <ListItemText
                     id={labelId}
                     primary={`Snapshot ${moment(s.created).format(
-                      'YYYY-MM-DD HH:MM'
+                      'YYYY-MM-DD HH:mm'
                     )}, value: ${calculateNetWorth([mapSnapshotToApiSnapshot(s)]).toFixed(2)}c`}
                   />
                 </ListItemButton>


### PR DESCRIPTION
Pull request addressing #861 
Fixed by updating the minutes portion of the moment.js format to use `mm` to indicate minutes instead of `MM` which indicates months